### PR TITLE
fixing tag creation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ script:
   - ./gradlew sonarqube
 deploy:
   provider: script
-  script: ./gradlew printVersion tag --push publishPlugins -Prelease
+  script: ./gradlew printVersion tag publishPlugins -Prelease && git push "https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git" $(git describe)
   on:
     branch: master
 before_cache:


### PR DESCRIPTION
## Proposed Changes
* pushes newly created tags outside of the gradle build since we need to be authenticated to push. See https://github.com/vivin/gradle-semantic-build-versioning/issues/73 
