### PR TITLE
ensuring environment bundle is first

### DIFF
--- a/environment-creator-application/src/main/java/com/ca/apim/gateway/cagatewayconfig/EnvironmentCreatorApplication.java
+++ b/environment-creator-application/src/main/java/com/ca/apim/gateway/cagatewayconfig/EnvironmentCreatorApplication.java
@@ -72,7 +72,7 @@ public class EnvironmentCreatorApplication {
         BundleEntityBuilder bundleEntityBuilder = ConfigBuilderModule.getInjector().getInstance(BundleEntityBuilder.class);
 
         Element bundleElement = bundleEntityBuilder.build(environmentBundle, EntityBuilder.BundleType.ENVIRONMENT, document);
-        documentFileUtils.createFile(bundleElement, new File(bootstrapBundleFolderPath, "_env.req.bundle").toPath());
+        documentFileUtils.createFile(bundleElement, new File(bootstrapBundleFolderPath, "_0_env.req.bundle").toPath());
     }
 
     private void processDeploymentBundles(Bundle environmentBundle) {

--- a/environment-creator-application/src/test/java/com/ca/apim/gateway/cagatewayconfig/EnvironmentCreatorApplicationTest.java
+++ b/environment-creator-application/src/test/java/com/ca/apim/gateway/cagatewayconfig/EnvironmentCreatorApplicationTest.java
@@ -39,7 +39,7 @@ class EnvironmentCreatorApplicationTest {
 
         new EnvironmentCreatorApplication(environmentProperties, testTemplatizedBundlesFolder.getPath(), testDetemplatizedBundlesFolder.getPath()).run();
 
-        File environmentBundle = new File(testDetemplatizedBundlesFolder, "_env.req.bundle");
+        File environmentBundle = new File(testDetemplatizedBundlesFolder, "_0_env.req.bundle");
 
         assertTrue(environmentBundle.exists());
     }
@@ -121,7 +121,7 @@ class EnvironmentCreatorApplicationTest {
 
         new EnvironmentCreatorApplication(environmentProperties, testTemplatizedBundlesFolder.getPath(), testDetemplatizedBundlesFolder.getPath()).run();
 
-        File environmentBundleFile = new File(testDetemplatizedBundlesFolder, "_env.req.bundle");
+        File environmentBundleFile = new File(testDetemplatizedBundlesFolder, "_0_env.req.bundle");
         assertTrue(environmentBundleFile.exists());
         System.out.println(new String(Files.readAllBytes(environmentBundleFile.toPath())));
 

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/tasks/gw7/Packager.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/tasks/gw7/Packager.java
@@ -49,14 +49,14 @@ class Packager {
     void buildPackage(File gw7File, File bundle, LinkedList<File> dependencyBundles, Set<File> containerApplicationDependencies) {
         byte[] applyEnvBytes = getResourceBytes("/scripts/apply-environment.sh");
 
-        AtomicInteger dependencyBundleCounter = new AtomicInteger(0);
-        int numBundles = dependencyBundles.size() + 1;
+        AtomicInteger dependencyBundleCounter = new AtomicInteger(1);
+        int numBundles = dependencyBundles.size() + 2;
         Set<GW7Builder.PackageFile> packageFiles = Stream.of(
                 // adds dependency bundles
                 StreamSupport.stream(Spliterators.spliteratorUnknownSize(dependencyBundles.descendingIterator(), Spliterator.ORDERED), false) // reverses the order of the dependencyBundles
                         .map(f -> new GW7Builder.PackageFile(DIRECTORY_OPT_DOCKER_RC_D + "bundle/templatized/_" + getFileCounter(numBundles, dependencyBundleCounter.getAndIncrement()) + "_" + f.getName(), f.length(), () -> fileUtils.getInputStream(f))),
                 //adds the deployment bundle
-                Stream.of(new GW7Builder.PackageFile(DIRECTORY_OPT_DOCKER_RC_D + "bundle/templatized/_" + getFileCounter(numBundles, dependencyBundles.size()) + "_" + bundle.getName(), bundle.length(), () -> fileUtils.getInputStream(bundle))),
+                Stream.of(new GW7Builder.PackageFile(DIRECTORY_OPT_DOCKER_RC_D + "bundle/templatized/_" + getFileCounter(numBundles, dependencyBundles.size() + 1) + "_" + bundle.getName(), bundle.length(), () -> fileUtils.getInputStream(bundle))),
                 //apply-environment.sh script
                 Stream.<GW7Builder.PackageFile>builder()
                         .add(new GW7Builder.PackageFile(DIRECTORY_OPT_DOCKER_RC_D + "apply-environment.sh", applyEnvBytes.length, () -> new ByteArrayInputStream(applyEnvBytes), true))

--- a/gateway-developer-plugin/src/test/java/com/ca/apim/gateway/capublisherplugin/CAGatewayDeveloperTest.java
+++ b/gateway-developer-plugin/src/test/java/com/ca/apim/gateway/capublisherplugin/CAGatewayDeveloperTest.java
@@ -110,10 +110,10 @@ class CAGatewayDeveloperTest {
         while ((entry = tarArchiveInputStream.getNextTarEntry()) != null) {
             entries.add(entry.getName());
         }
-        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_0_project-b-1.2.3-SNAPSHOT.req.bundle"));
-        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_1_project-d-1.2.3-SNAPSHOT.req.bundle"));
-        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_2_project-a-1.2.3-SNAPSHOT.req.bundle"));
-        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_3_project-c-1.2.3-SNAPSHOT.req.bundle"));
+        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_1_project-b-1.2.3-SNAPSHOT.req.bundle"));
+        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_2_project-d-1.2.3-SNAPSHOT.req.bundle"));
+        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_3_project-a-1.2.3-SNAPSHOT.req.bundle"));
+        assertTrue(entries.contains("opt/docker/rc.d/bundle/templatized/_4_project-c-1.2.3-SNAPSHOT.req.bundle"));
     }
 
     private void validateBuildDir(String projectName, File buildDir) {


### PR DESCRIPTION
## Proposed Changes
* The environment bundle will be named `_0_env.req.bundle` when it is created by the environment creator application
* The deployment bundle numberings will start at 1
