### PR TITLE
Create and export cluster properties without the ENV. prefix

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/tasks/zip/builder/ClusterPropertyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/tasks/zip/builder/ClusterPropertyEntityBuilder.java
@@ -46,7 +46,7 @@ public class ClusterPropertyEntityBuilder implements EntityBuilder {
             case DEPLOYMENT:
                 bundle.getStaticProperties().entrySet().stream().map(propertyEntry -> {
                     if (bundle.getEnvironmentProperties().containsKey(PREFIX_GATEWAY + propertyEntry.getKey())) {
-                        throw new EntityBuilderException("The Cluster property: " + propertyEntry.getKey() + " is defined in both static.properties and env.properties");
+                        throw new EntityBuilderException("The Cluster property: '" + propertyEntry.getKey() + "' is defined in both static.properties and env.properties");
                     }
                     return buildClusterPropertyEntity(propertyEntry.getKey(), propertyEntry.getValue(), document);
                 }).forEach(streamBuilder);

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/tasks/zip/builder/ClusterPropertyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/tasks/zip/builder/ClusterPropertyEntityBuilder.java
@@ -50,14 +50,14 @@ public class ClusterPropertyEntityBuilder implements EntityBuilder {
                 bundle.getEnvironmentProperties().entrySet().stream()
                         .filter(propertyEntry -> propertyEntry.getKey().startsWith(PREFIX_GATEWAY))
                         .map(propertyEntry ->
-                                getEntityWithOnlyMapping(CLUSTER_PROPERTY_TYPE, PREFIX_ENV + propertyEntry.getKey().substring(8), idGenerator.generate())
+                                getEntityWithOnlyMapping(CLUSTER_PROPERTY_TYPE, propertyEntry.getKey().substring(8), idGenerator.generate())
                         ).forEach(streamBuilder);
                 break;
             case ENVIRONMENT:
                 bundle.getEnvironmentProperties().entrySet().stream()
                         .filter(propertyEntry -> propertyEntry.getKey().startsWith(PREFIX_GATEWAY))
                         .map(propertyEntry ->
-                                buildClusterPropertyEntity(PREFIX_ENV + propertyEntry.getKey().substring(8), propertyEntry.getValue(), document)
+                                buildClusterPropertyEntity(propertyEntry.getKey().substring(8), propertyEntry.getValue(), document)
                         ).forEach(streamBuilder);
                 break;
             default:

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/tasks/zip/builder/ClusterPropertyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/tasks/zip/builder/ClusterPropertyEntityBuilder.java
@@ -50,14 +50,14 @@ public class ClusterPropertyEntityBuilder implements EntityBuilder {
                 bundle.getEnvironmentProperties().entrySet().stream()
                         .filter(propertyEntry -> propertyEntry.getKey().startsWith(PREFIX_GATEWAY))
                         .map(propertyEntry ->
-                                getEntityWithOnlyMapping(CLUSTER_PROPERTY_TYPE, propertyEntry.getKey().substring(8), idGenerator.generate())
+                                getEntityWithOnlyMapping(CLUSTER_PROPERTY_TYPE, propertyEntry.getKey().substring(PREFIX_GATEWAY.length()), idGenerator.generate())
                         ).forEach(streamBuilder);
                 break;
             case ENVIRONMENT:
                 bundle.getEnvironmentProperties().entrySet().stream()
                         .filter(propertyEntry -> propertyEntry.getKey().startsWith(PREFIX_GATEWAY))
                         .map(propertyEntry ->
-                                buildClusterPropertyEntity(propertyEntry.getKey().substring(8), propertyEntry.getValue(), document)
+                                buildClusterPropertyEntity(propertyEntry.getKey().substring(PREFIX_GATEWAY.length()), propertyEntry.getValue(), document)
                         ).forEach(streamBuilder);
                 break;
             default:

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/tasks/zip/builder/ClusterPropertyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/tasks/zip/builder/ClusterPropertyEntityBuilder.java
@@ -44,9 +44,12 @@ public class ClusterPropertyEntityBuilder implements EntityBuilder {
         Stream.Builder<Entity> streamBuilder = Stream.builder();
         switch (bundleType) {
             case DEPLOYMENT:
-                bundle.getStaticProperties().entrySet().stream().map(propertyEntry ->
-                        buildClusterPropertyEntity(propertyEntry.getKey(), propertyEntry.getValue(), document)
-                ).forEach(streamBuilder);
+                bundle.getStaticProperties().entrySet().stream().map(propertyEntry -> {
+                    if (bundle.getEnvironmentProperties().containsKey(PREFIX_GATEWAY + propertyEntry.getKey())) {
+                        throw new EntityBuilderException("The Cluster property: " + propertyEntry.getKey() + " is defined in both static.properties and env.properties");
+                    }
+                    return buildClusterPropertyEntity(propertyEntry.getKey(), propertyEntry.getValue(), document);
+                }).forEach(streamBuilder);
                 bundle.getEnvironmentProperties().entrySet().stream()
                         .filter(propertyEntry -> propertyEntry.getKey().startsWith(PREFIX_GATEWAY))
                         .map(propertyEntry ->

--- a/environment-creator-application/src/main/java/com/ca/apim/gateway/cagatewayconfig/BundleEnvironmentValidator.java
+++ b/environment-creator-application/src/main/java/com/ca/apim/gateway/cagatewayconfig/BundleEnvironmentValidator.java
@@ -19,6 +19,7 @@ import java.util.stream.Collectors;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingProperties.*;
+import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.PREFIX_GATEWAY;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.*;
 
 public class BundleEnvironmentValidator {
@@ -66,7 +67,7 @@ public class BundleEnvironmentValidator {
     private void findInBundle(Bundle bundle, String type, String name) {
         switch (type) {
             case EntityTypes.CLUSTER_PROPERTY_TYPE:
-                if (bundle.getEnvironmentProperties().get(name) == null) {
+                if (bundle.getEnvironmentProperties().get(PREFIX_GATEWAY + name) == null) {
                     throw new MissingEnvironmentException("Missing environment value for property: " + name);
                 }
                 break;

--- a/environment-creator-application/src/test/java/com/ca/apim/gateway/cagatewayconfig/BundleEnvironmentValidatorTest.java
+++ b/environment-creator-application/src/test/java/com/ca/apim/gateway/cagatewayconfig/BundleEnvironmentValidatorTest.java
@@ -14,6 +14,7 @@ import com.ca.apim.gateway.cagatewayconfig.tasks.zip.beans.identityprovider.Iden
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
+import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.PREFIX_GATEWAY;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -210,7 +211,7 @@ class BundleEnvironmentValidatorTest {
     @Test
     void validateEnvironmentProvidedClusterProperty() {
         Bundle environmentBundle = new Bundle();
-        environmentBundle.getEnvironmentProperties().put("myProperty", "value");
+        environmentBundle.getEnvironmentProperties().put(PREFIX_GATEWAY + "myProperty", "value");
         BundleEnvironmentValidator bundleEnvironmentValidator = new BundleEnvironmentValidator(environmentBundle);
 
         bundleEnvironmentValidator.validateEnvironmentProvided("myBundle", "" +

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/ExplodeBundle.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/ExplodeBundle.java
@@ -51,7 +51,7 @@ public class ExplodeBundle {
 
         //Link, simplify and process entities
         final Collection<EntitiesLinker> entityLinkers = entityLinkerRegistry.getEntityLinkers();
-        entityLinkers.parallelStream().forEach(e -> e.link(filteredBundle, bundle));
+        entityLinkers.parallelStream().forEach(e -> e.link(filteredBundle, bundle, explodeDirectory));
 
         //write the bundle in the exploded format
         final Collection<EntityWriter> entityBuilders = entityWriterRegistry.getEntityWriters();

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ClusterPropertyLinker.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ClusterPropertyLinker.java
@@ -9,9 +9,7 @@ package com.ca.apim.gateway.cagatewayexport.tasks.explode.linker;
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.bundle.Bundle;
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.bundle.entity.ClusterProperty;
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.bundle.entity.EnvironmentProperty;
-import com.ca.apim.gateway.cagatewayexport.util.file.DocumentFileUtils;
 
-import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.File;
 import java.util.HashSet;
@@ -19,15 +17,10 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
+import static com.ca.apim.gateway.cagatewayexport.util.properties.PropertyFileUtils.loadExistingProperties;
+
 @Singleton
 public class ClusterPropertyLinker implements EntitiesLinker {
-    private DocumentFileUtils documentFileUtils;
-
-    @Inject
-    ClusterPropertyLinker(DocumentFileUtils documentFileUtils) {
-        this.documentFileUtils = documentFileUtils;
-    }
-
     @Override
     public void link(Bundle filteredBundle, Bundle bundle) {
         throw new UnsupportedOperationException();
@@ -38,7 +31,7 @@ public class ClusterPropertyLinker implements EntitiesLinker {
         Map<String, ClusterProperty> clusterPropertyMap = filteredBundle.getEntities(ClusterProperty.class);
         Set<String> idsToRemove = new HashSet<>();
         File propertiesFile = new File(new File(rootFolder, "config"), "static.properties");
-        Properties staticProperties = documentFileUtils.loadExistingProperties(propertiesFile, "static");
+        Properties staticProperties = loadExistingProperties(propertiesFile);
 
         for (ClusterProperty clusterProperty : clusterPropertyMap.values()) {
             if (!staticProperties.containsKey(clusterProperty.getName())) {

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ClusterPropertyLinker.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ClusterPropertyLinker.java
@@ -22,10 +22,8 @@ public class ClusterPropertyLinker implements EntitiesLinker {
         Map<String, ClusterProperty> clusterPropertyMap = filteredBundle.getEntities(ClusterProperty.class);
         Set<String> idsToRemove = new HashSet<>();
         for (ClusterProperty clusterProperty : clusterPropertyMap.values()) {
-            if (clusterProperty.getName().startsWith("ENV.")) {
-                filteredBundle.addEntity(new EnvironmentProperty(clusterProperty.getName().substring(4), clusterProperty.getValue(), EnvironmentProperty.Type.GLOBAL));
-                idsToRemove.add(clusterProperty.getId());
-            }
+            filteredBundle.addEntity(new EnvironmentProperty(clusterProperty.getName(), clusterProperty.getValue(), EnvironmentProperty.Type.GLOBAL));
+            idsToRemove.add(clusterProperty.getId());
         }
         idsToRemove.forEach(clusterPropertyMap::remove);
     }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ClusterPropertyLinker.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ClusterPropertyLinker.java
@@ -9,14 +9,11 @@ package com.ca.apim.gateway.cagatewayexport.tasks.explode.linker;
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.bundle.Bundle;
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.bundle.entity.ClusterProperty;
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.bundle.entity.EnvironmentProperty;
-import com.ca.apim.gateway.cagatewayexport.util.properties.OrderedProperties;
-import org.jetbrains.annotations.NotNull;
+import com.ca.apim.gateway.cagatewayexport.util.file.DocumentFileUtils;
 
+import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Properties;
@@ -24,6 +21,13 @@ import java.util.Set;
 
 @Singleton
 public class ClusterPropertyLinker implements EntitiesLinker {
+    private DocumentFileUtils documentFileUtils;
+
+    @Inject
+    ClusterPropertyLinker(DocumentFileUtils documentFileUtils) {
+        this.documentFileUtils = documentFileUtils;
+    }
+
     @Override
     public void link(Bundle filteredBundle, Bundle bundle) {
         throw new UnsupportedOperationException();
@@ -33,7 +37,8 @@ public class ClusterPropertyLinker implements EntitiesLinker {
     public void link(Bundle filteredBundle, Bundle bundle, File rootFolder) {
         Map<String, ClusterProperty> clusterPropertyMap = filteredBundle.getEntities(ClusterProperty.class);
         Set<String> idsToRemove = new HashSet<>();
-        Properties staticProperties = getExistingProperties(rootFolder);
+        File propertiesFile = new File(new File(rootFolder, "config"), "static.properties");
+        Properties staticProperties = documentFileUtils.loadExistingProperties(propertiesFile, "static");
 
         for (ClusterProperty clusterProperty : clusterPropertyMap.values()) {
             if (!staticProperties.containsKey(clusterProperty.getName())) {
@@ -44,17 +49,4 @@ public class ClusterPropertyLinker implements EntitiesLinker {
         idsToRemove.forEach(clusterPropertyMap::remove);
     }
 
-    @NotNull
-    private Properties getExistingProperties(File rootFolder) {
-        File propertiesFile = new File(new File(rootFolder, "config"), "static.properties");
-        Properties staticProperties = new OrderedProperties();
-        if (propertiesFile.exists()) {
-            try (InputStream stream = Files.newInputStream(propertiesFile.toPath())) {
-                staticProperties.load(stream);
-            } catch (IOException e) {
-                throw new LinkerException("Exception reading existing contents from static.properties file", e);
-            }
-        }
-        return staticProperties;
-    }
 }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ClusterPropertyLinker.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ClusterPropertyLinker.java
@@ -9,22 +9,52 @@ package com.ca.apim.gateway.cagatewayexport.tasks.explode.linker;
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.bundle.Bundle;
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.bundle.entity.ClusterProperty;
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.bundle.entity.EnvironmentProperty;
+import com.ca.apim.gateway.cagatewayexport.util.properties.OrderedProperties;
+import org.jetbrains.annotations.NotNull;
 
 import javax.inject.Singleton;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 @Singleton
 public class ClusterPropertyLinker implements EntitiesLinker {
     @Override
     public void link(Bundle filteredBundle, Bundle bundle) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void link(Bundle filteredBundle, Bundle bundle, File rootFolder) {
         Map<String, ClusterProperty> clusterPropertyMap = filteredBundle.getEntities(ClusterProperty.class);
         Set<String> idsToRemove = new HashSet<>();
+        Properties staticProperties = getExistingProperties(rootFolder);
+
         for (ClusterProperty clusterProperty : clusterPropertyMap.values()) {
-            filteredBundle.addEntity(new EnvironmentProperty(clusterProperty.getName(), clusterProperty.getValue(), EnvironmentProperty.Type.GLOBAL));
-            idsToRemove.add(clusterProperty.getId());
+            if (!staticProperties.containsKey(clusterProperty.getName())) {
+                filteredBundle.addEntity(new EnvironmentProperty(clusterProperty.getName(), clusterProperty.getValue(), EnvironmentProperty.Type.GLOBAL));
+                idsToRemove.add(clusterProperty.getId());
+            }
         }
         idsToRemove.forEach(clusterPropertyMap::remove);
+    }
+
+    @NotNull
+    private Properties getExistingProperties(File rootFolder) {
+        File propertiesFile = new File(new File(rootFolder, "config"), "static.properties");
+        Properties staticProperties = new OrderedProperties();
+        if (propertiesFile.exists()) {
+            try (InputStream stream = Files.newInputStream(propertiesFile.toPath())) {
+                staticProperties.load(stream);
+            } catch (IOException e) {
+                throw new LinkerException("Exception reading existing contents from static.properties file", e);
+            }
+        }
+        return staticProperties;
     }
 }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EntitiesLinker.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EntitiesLinker.java
@@ -8,7 +8,13 @@ package com.ca.apim.gateway.cagatewayexport.tasks.explode.linker;
 
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.bundle.Bundle;
 
+import java.io.File;
+
 public interface EntitiesLinker {
 
     void link(Bundle filteredBundle, Bundle bundle);
+
+    default void link(Bundle filteredBundle, Bundle bundle, File rootFolder) {
+        link(filteredBundle, bundle);
+    }
 }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/LinkerException.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/LinkerException.java
@@ -10,4 +10,9 @@ public class LinkerException extends RuntimeException {
     public LinkerException(String message) {
         super(message);
     }
+
+    public LinkerException(String message, Exception e) {
+        super(message, e);
+    }
+
 }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/PropertyFileException.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/PropertyFileException.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2018. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+package com.ca.apim.gateway.cagatewayexport.tasks.explode.writer;
+
+public class PropertyFileException extends RuntimeException {
+    public PropertyFileException(String message) {
+        super(message);
+    }
+
+    public PropertyFileException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/WriterHelper.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/WriterHelper.java
@@ -17,6 +17,7 @@ import java.io.*;
 import java.nio.file.Files;
 import java.util.*;
 
+import static com.ca.apim.gateway.cagatewayexport.util.properties.PropertyFileUtils.loadExistingProperties;
 import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
@@ -46,7 +47,7 @@ class WriterHelper {
         documentFileUtils.createFolder(configFolder.toPath());
 
         File propertiesFile = new File(configFolder, fileName + ".properties");
-        Properties currentProperties = documentFileUtils.loadExistingProperties(propertiesFile, fileName);
+        Properties currentProperties = loadExistingProperties(propertiesFile);
         if (!currentProperties.isEmpty()) {
             // iterate the new properties and join them to the current properties contents
             // new property value is chosen except if its value is null

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/WriterHelper.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/WriterHelper.java
@@ -9,7 +9,6 @@ package com.ca.apim.gateway.cagatewayexport.tasks.explode.writer;
 import com.ca.apim.gateway.cagatewayexport.util.file.DocumentFileUtils;
 import com.ca.apim.gateway.cagatewayexport.util.file.StripFirstLineStream;
 import com.ca.apim.gateway.cagatewayexport.util.json.JsonTools;
-import com.ca.apim.gateway.cagatewayexport.util.properties.OrderedProperties;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.type.MapType;
@@ -47,15 +46,8 @@ class WriterHelper {
         documentFileUtils.createFolder(configFolder.toPath());
 
         File propertiesFile = new File(configFolder, fileName + ".properties");
-        // check if the properties file exist and load current properties into the properties object
-        if (propertiesFile.exists()) {
-            Properties currentProperties = new OrderedProperties();
-            try (InputStream stream = Files.newInputStream(propertiesFile.toPath())){
-                currentProperties.load(stream);
-            } catch (IOException e) {
-                throw new WriteException("Exception reading existing contents from " + fileName + " properties file", e);
-            }
-
+        Properties currentProperties = documentFileUtils.loadExistingProperties(propertiesFile, fileName);
+        if (!currentProperties.isEmpty()) {
             // iterate the new properties and join them to the current properties contents
             // new property value is chosen except if its value is null
             properties

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/file/DocumentFileUtils.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/file/DocumentFileUtils.java
@@ -7,19 +7,19 @@
 package com.ca.apim.gateway.cagatewayexport.util.file;
 
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.writer.WriteException;
+import com.ca.apim.gateway.cagatewayexport.util.properties.OrderedProperties;
 import com.ca.apim.gateway.cagatewayexport.util.xml.DocumentTools;
+import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.Element;
 
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerException;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.UnsupportedEncodingException;
+import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -92,6 +92,20 @@ public final class DocumentFileUtils {
         } catch (TransformerException e) {
             throw new DocumentFileUtilsException("Exception writing xml element to stream.", e);
         }
+    }
+
+    @NotNull
+    public Properties loadExistingProperties(File propertiesFile, String fileName) {
+        Properties properties = new OrderedProperties();
+        // check if the properties file exist and load current properties into the properties object
+        if (propertiesFile.exists()) {
+            try (InputStream stream = Files.newInputStream(propertiesFile.toPath())) {
+                properties.load(stream);
+            } catch (IOException e) {
+                throw new DocumentFileUtilsException("Exception reading existing contents from " + fileName + ".properties file", e);
+            }
+        }
+        return properties;
     }
 
 

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/file/DocumentFileUtils.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/file/DocumentFileUtils.java
@@ -7,9 +7,7 @@
 package com.ca.apim.gateway.cagatewayexport.util.file;
 
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.writer.WriteException;
-import com.ca.apim.gateway.cagatewayexport.util.properties.OrderedProperties;
 import com.ca.apim.gateway.cagatewayexport.util.xml.DocumentTools;
-import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.Element;
 
 import javax.xml.transform.Transformer;
@@ -19,7 +17,6 @@ import javax.xml.transform.stream.StreamResult;
 import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Properties;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -93,21 +90,6 @@ public final class DocumentFileUtils {
             throw new DocumentFileUtilsException("Exception writing xml element to stream.", e);
         }
     }
-
-    @NotNull
-    public Properties loadExistingProperties(File propertiesFile, String fileName) {
-        Properties properties = new OrderedProperties();
-        // check if the properties file exist and load current properties into the properties object
-        if (propertiesFile.exists()) {
-            try (InputStream stream = Files.newInputStream(propertiesFile.toPath())) {
-                properties.load(stream);
-            } catch (IOException e) {
-                throw new DocumentFileUtilsException("Exception reading existing contents from " + fileName + ".properties file", e);
-            }
-        }
-        return properties;
-    }
-
 
     /**
      * Close a {@link java.io.Closeable} without throwing any exceptions.

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/properties/PropertyFileException.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/properties/PropertyFileException.java
@@ -4,7 +4,7 @@
  * of the MIT license.  See the LICENSE file for details.
  */
 
-package com.ca.apim.gateway.cagatewayexport.tasks.explode.writer;
+package com.ca.apim.gateway.cagatewayexport.util.properties;
 
 public class PropertyFileException extends RuntimeException {
     public PropertyFileException(String message) {

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/properties/PropertyFileUtils.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/properties/PropertyFileUtils.java
@@ -6,7 +6,6 @@
 
 package com.ca.apim.gateway.cagatewayexport.util.properties;
 
-import com.ca.apim.gateway.cagatewayexport.tasks.explode.writer.PropertyFileException;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/properties/PropertyFileUtils.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/properties/PropertyFileUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+package com.ca.apim.gateway.cagatewayexport.util.properties;
+
+import com.ca.apim.gateway.cagatewayexport.tasks.explode.writer.PropertyFileException;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.util.Properties;
+
+public class PropertyFileUtils {
+
+    @NotNull
+    public static Properties loadExistingProperties(File propertiesFile) {
+        Properties properties = new OrderedProperties();
+        // check if the properties file exist and load current properties into the properties object
+        if (propertiesFile.exists()) {
+            try (InputStream stream = Files.newInputStream(propertiesFile.toPath())) {
+                properties.load(stream);
+            } catch (IOException e) {
+                throw new PropertyFileException("Exception reading existing contents from " + propertiesFile.getName() + " file", e);
+            }
+        }
+        return properties;
+    }
+
+    private PropertyFileUtils(){}
+}

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/CAGatewayExportTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/CAGatewayExportTest.java
@@ -83,13 +83,13 @@ class CAGatewayExportTest {
         assertTrue(environmentProperties.containsKey("empty-value"));
         assertTrue(environmentProperties.containsKey("message-variable"));
         assertTrue(environmentProperties.containsKey("local.env.var"));
-        assertTrue(environmentProperties.containsKey("gateway.my-global-property"));
-        assertTrue(environmentProperties.containsKey("gateway.another.global"));
+        assertTrue(environmentProperties.containsKey("gateway.ENV.my-global-property"));
+        assertTrue(environmentProperties.containsKey("gateway.ENV.another.global"));
 
-        Properties staticProperties = new Properties();
-        staticProperties.load(new FileReader(new File(configDir, "static.properties")));
-        assertTrue(staticProperties.containsKey("that-property"));
-        assertFalse(staticProperties.containsKey("this-property"));
+//        Properties staticProperties = new Properties();
+//        staticProperties.load(new FileReader(new File(configDir, "static.properties")));
+//        assertTrue(staticProperties.containsKey("that-property"));
+//        assertFalse(staticProperties.containsKey("this-property"));
 
         File passwordsFile = new File(configDir, "stored-passwords.properties");
         assertTrue(passwordsFile.exists());

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/CAGatewayExportTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/CAGatewayExportTest.java
@@ -86,10 +86,7 @@ class CAGatewayExportTest {
         assertTrue(environmentProperties.containsKey("gateway.ENV.my-global-property"));
         assertTrue(environmentProperties.containsKey("gateway.ENV.another.global"));
 
-//        Properties staticProperties = new Properties();
-//        staticProperties.load(new FileReader(new File(configDir, "static.properties")));
-//        assertTrue(staticProperties.containsKey("that-property"));
-//        assertFalse(staticProperties.containsKey("this-property"));
+        assertFalse(new File(configDir, "static.properties").exists());
 
         File passwordsFile = new File(configDir, "stored-passwords.properties");
         assertTrue(passwordsFile.exists());

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ClusterPropertyLinkerTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ClusterPropertyLinkerTest.java
@@ -28,14 +28,14 @@ class ClusterPropertyLinkerTest {
 
         clusterPropertyLinker.link(bundle, null);
 
-        assertEquals(2, bundle.getEntities(ClusterProperty.class).size());
-        assertEquals(2, bundle.getEntities(EnvironmentProperty.class).size());
+        assertEquals(0, bundle.getEntities(ClusterProperty.class).size());
+        assertEquals(4, bundle.getEntities(EnvironmentProperty.class).size());
 
         assertTrue(bundle.getEntities(EnvironmentProperty.class).containsKey("GLOBAL:my.name"));
         assertEquals("my.name", bundle.getEntities(EnvironmentProperty.class).get("GLOBAL:my.name").getName());
         assertEquals(EnvironmentProperty.Type.GLOBAL, bundle.getEntities(EnvironmentProperty.class).get("GLOBAL:my.name").getType());
-        assertTrue(bundle.getEntities(EnvironmentProperty.class).containsKey("GLOBAL:hello"));
-        assertEquals("hello", bundle.getEntities(EnvironmentProperty.class).get("GLOBAL:hello").getName());
+        assertTrue(bundle.getEntities(EnvironmentProperty.class).containsKey("GLOBAL:ENV.hello"));
+        assertEquals("ENV.hello", bundle.getEntities(EnvironmentProperty.class).get("GLOBAL:ENV.hello").getName());
 
     }
 }

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ClusterPropertyLinkerTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ClusterPropertyLinkerTest.java
@@ -9,6 +9,7 @@ package com.ca.apim.gateway.cagatewayexport.tasks.explode.linker;
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.bundle.Bundle;
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.bundle.entity.ClusterProperty;
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.bundle.entity.EnvironmentProperty;
+import com.ca.apim.gateway.cagatewayexport.util.file.DocumentFileUtils;
 import com.ca.apim.gateway.cagatewayexport.util.file.StripFirstLineStream;
 import com.ca.apim.gateway.cagatewayexport.util.properties.OrderedProperties;
 import io.github.glytching.junit.extension.folder.TemporaryFolder;
@@ -35,7 +36,7 @@ class ClusterPropertyLinkerTest {
 
     @BeforeEach
     void setUp() {
-        clusterPropertyLinker = new ClusterPropertyLinker();
+        clusterPropertyLinker = new ClusterPropertyLinker(DocumentFileUtils.INSTANCE);
         bundle = new Bundle();
         bundle.addEntity(new ClusterProperty("my.name", "my-value", "1"));
         bundle.addEntity(new ClusterProperty("ENV.my.name", "my-value", "2"));

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ClusterPropertyLinkerTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ClusterPropertyLinkerTest.java
@@ -9,33 +9,92 @@ package com.ca.apim.gateway.cagatewayexport.tasks.explode.linker;
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.bundle.Bundle;
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.bundle.entity.ClusterProperty;
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.bundle.entity.EnvironmentProperty;
+import com.ca.apim.gateway.cagatewayexport.util.file.StripFirstLineStream;
+import com.ca.apim.gateway.cagatewayexport.util.properties.OrderedProperties;
+import io.github.glytching.junit.extension.folder.TemporaryFolder;
+import io.github.glytching.junit.extension.folder.TemporaryFolderExtension;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Properties;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@ExtendWith(TemporaryFolderExtension.class)
 class ClusterPropertyLinkerTest {
 
-    @Test
-    void link() {
-        ClusterPropertyLinker clusterPropertyLinker = new ClusterPropertyLinker();
+    private Bundle bundle;
+    private ClusterPropertyLinker clusterPropertyLinker;
 
-        Bundle bundle = new Bundle();
+    @BeforeEach
+    void setUp() {
+        clusterPropertyLinker = new ClusterPropertyLinker();
+        bundle = new Bundle();
         bundle.addEntity(new ClusterProperty("my.name", "my-value", "1"));
         bundle.addEntity(new ClusterProperty("ENV.my.name", "my-value", "2"));
         bundle.addEntity(new ClusterProperty("another", "my-value", "3"));
         bundle.addEntity(new ClusterProperty("ENV.hello", "my-value", "4"));
+    }
 
-        clusterPropertyLinker.link(bundle, null);
+    @Test
+    void linkUnsupportedOperation() {
+        assertThrows(UnsupportedOperationException.class, () -> clusterPropertyLinker.link(bundle, null));
+    }
+
+    @Test
+    void linkNoStaticPropertiesFile(TemporaryFolder temporaryFolder) {
+        clusterPropertyLinker.link(bundle, null, temporaryFolder.getRoot());
 
         assertEquals(0, bundle.getEntities(ClusterProperty.class).size());
         assertEquals(4, bundle.getEntities(EnvironmentProperty.class).size());
 
-        assertTrue(bundle.getEntities(EnvironmentProperty.class).containsKey("GLOBAL:my.name"));
-        assertEquals("my.name", bundle.getEntities(EnvironmentProperty.class).get("GLOBAL:my.name").getName());
-        assertEquals(EnvironmentProperty.Type.GLOBAL, bundle.getEntities(EnvironmentProperty.class).get("GLOBAL:my.name").getType());
+        verifyEnvironmentProperties();
+    }
+
+    @Test
+    void linkStaticPropertiesFile(TemporaryFolder temporaryFolder) throws IOException {
+        // Set up static properties file
+        File configFolder = temporaryFolder.createDirectory("config");
+        File propertiesFile = new File(configFolder, "static.properties");
+        Properties staticProps = new OrderedProperties();
+        staticProps.setProperty("my.name", "static value");
+        staticProps.setProperty("another", "another static value");
+
+        try (OutputStream outputStream = new StripFirstLineStream(new FileOutputStream(propertiesFile))) {
+            staticProps.store(outputStream, null);
+        }
+
+        // Test
+        clusterPropertyLinker.link(bundle, null, temporaryFolder.getRoot());
+
+        assertEquals(2, bundle.getEntities(ClusterProperty.class).size());
+        assertEquals(2, bundle.getEntities(EnvironmentProperty.class).size());
+
+        // static.properties are considered ClusterProperties
+        assertEquals("my.name", bundle.getEntities(ClusterProperty.class).get("1").getName());
+        assertEquals("another", bundle.getEntities(ClusterProperty.class).get("3").getName());
+
+        // value from static.properties is replaced
+        assertEquals("my-value", bundle.getEntities(ClusterProperty.class).get("1").getValue());
+        assertEquals("my-value", bundle.getEntities(ClusterProperty.class).get("3").getValue());
+
+        verifyEnvironmentProperties();
+    }
+
+    private void verifyEnvironmentProperties() {
+        assertTrue(bundle.getEntities(EnvironmentProperty.class).containsKey("GLOBAL:ENV.my.name"));
+        assertEquals("ENV.my.name", bundle.getEntities(EnvironmentProperty.class).get("GLOBAL:ENV.my.name").getName());
+        assertEquals(EnvironmentProperty.Type.GLOBAL, bundle.getEntities(EnvironmentProperty.class).get("GLOBAL:ENV.my.name").getType());
         assertTrue(bundle.getEntities(EnvironmentProperty.class).containsKey("GLOBAL:ENV.hello"));
         assertEquals("ENV.hello", bundle.getEntities(EnvironmentProperty.class).get("GLOBAL:ENV.hello").getName());
+        assertEquals(EnvironmentProperty.Type.GLOBAL, bundle.getEntities(EnvironmentProperty.class).get("GLOBAL:ENV.hello").getType());
 
     }
 }

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ClusterPropertyLinkerTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ClusterPropertyLinkerTest.java
@@ -36,7 +36,7 @@ class ClusterPropertyLinkerTest {
 
     @BeforeEach
     void setUp() {
-        clusterPropertyLinker = new ClusterPropertyLinker(DocumentFileUtils.INSTANCE);
+        clusterPropertyLinker = new ClusterPropertyLinker();
         bundle = new Bundle();
         bundle.addEntity(new ClusterProperty("my.name", "my-value", "1"));
         bundle.addEntity(new ClusterProperty("ENV.my.name", "my-value", "2"));

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/util/properties/PropertyFileUtilsTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/util/properties/PropertyFileUtilsTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+package com.ca.apim.gateway.cagatewayexport.util.properties;
+
+import com.ca.apim.gateway.cagatewayexport.util.file.StripFirstLineStream;
+import io.github.glytching.junit.extension.folder.TemporaryFolder;
+import io.github.glytching.junit.extension.folder.TemporaryFolderExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Properties;
+
+import static com.ca.apim.gateway.cagatewayexport.util.properties.PropertyFileUtils.loadExistingProperties;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(TemporaryFolderExtension.class)
+class PropertyFileUtilsTest {
+
+    @Test
+    void loadExistingPropertiesNoProperties(TemporaryFolder temporaryFolder) {
+        assertTrue(loadExistingProperties(new File(temporaryFolder.getRoot(), "static.properties")).isEmpty());
+    }
+
+    @Test
+    void loadExistingPropertiesFromFile(TemporaryFolder temporaryFolder) throws IOException {
+        File propertiesFile = new File(temporaryFolder.getRoot(), "static.properties");
+        Properties staticProps = new OrderedProperties();
+        staticProps.setProperty("my.name", "static value");
+        staticProps.setProperty("another", "another static value");
+
+        try (OutputStream outputStream = new StripFirstLineStream(new FileOutputStream(propertiesFile))) {
+            staticProps.store(outputStream, null);
+        }
+
+        Properties properties = loadExistingProperties(propertiesFile);
+        assertTrue(properties.containsKey("my.name"));
+        assertTrue(properties.containsKey("another"));
+    }
+
+}


### PR DESCRIPTION
Fixes #72 

## Proposed Changes
* Remove ENV. from cluster properties on the Gateway
* Fixed bug where bundleValidator never matches the cluster property name from the env.properties file with ENV.PROPERTY vars
* Exported cluster properties will be in the env.properties file with the prefix `gateway.` prepended to the cluster property name

Example:
To make a cluster property called "test" on the Gateway
* env.properties file
`gateway.test = <value>`
* docker-compose env var
`ENV.PROPERTY.gateway.test: <value>`

Exporting a cluster property called "test" will create an env.properties file with the entry `gateway.test=<value>`
