### PR TITLE
remove the .req extension when publishing bundle files

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/tasks/zip/BundleBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/tasks/zip/BundleBuilder.java
@@ -67,7 +67,7 @@ class BundleBuilder {
 
         //Zip
         Element bundleElement = bundleEntityBuilder.build(bundle, EntityBuilder.BundleType.DEPLOYMENT, document);
-        documentFileUtils.createFile(bundleElement, new File(outputDir, name + ".req.bundle").toPath());
+        documentFileUtils.createFile(bundleElement, new File(outputDir, name + ".bundle").toPath());
     }
 
 

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/CAGatewayDeveloper.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/CAGatewayDeveloper.java
@@ -23,7 +23,6 @@ public class CAGatewayDeveloper implements Plugin<Project> {
 
     private static final String BUNDLE_CONFIGURATION = "bundle";
     private static final String BUNDLE_FILE_EXTENSION = "bundle";
-    private static final String BUNDLE_REQUIRED_FILE_EXTENSION = "req." + BUNDLE_FILE_EXTENSION;
     private static final String BUILT_BUNDLE_DIRECTORY = "bundle";
     private static final String GATEWAY_BUILD_DIRECTORY = "gateway";
     private static final String ENV_APPLICATION_CONFIGURATION = "environment-creator-application";
@@ -65,7 +64,7 @@ public class CAGatewayDeveloper implements Plugin<Project> {
         final PackageTask packageGW7Task = project.getTasks().create("package-gw7", PackageTask.class, t -> {
             t.dependsOn(buildBundleTask);
             t.getInto().set(new DefaultProvider<RegularFile>(() -> () -> new File(new File(project.getBuildDir(), GATEWAY_BUILD_DIRECTORY), getBuiltArtifactName(project, "gw7"))));
-            t.getBundle().set(pluginConfig.getBuiltBundleDir().file(new DefaultProvider<>(() -> getBuiltArtifactName(project, BUNDLE_REQUIRED_FILE_EXTENSION))));
+            t.getBundle().set(pluginConfig.getBuiltBundleDir().file(new DefaultProvider<>(() -> getBuiltArtifactName(project, BUNDLE_FILE_EXTENSION))));
             t.getDependencyBundles().setFrom(project.getConfigurations().getByName(BUNDLE_CONFIGURATION));
             t.getContainerApplicationDependencies().setFrom(project.getConfigurations().getByName(ENV_APPLICATION_CONFIGURATION));
         });
@@ -84,7 +83,7 @@ public class CAGatewayDeveloper implements Plugin<Project> {
                         },
                         configurablePublishArtifact -> {
                             configurablePublishArtifact.builtBy(buildBundleTask);
-                            configurablePublishArtifact.setExtension(BUNDLE_REQUIRED_FILE_EXTENSION);
+                            configurablePublishArtifact.setExtension(BUNDLE_FILE_EXTENSION);
                             configurablePublishArtifact.setName(project.getName() + '-' + project.getVersion());
                             configurablePublishArtifact.setType(BUNDLE_FILE_EXTENSION);
                         }));

--- a/gateway-developer-plugin/src/test/java/com/ca/apim/gateway/capublisherplugin/CAGatewayDeveloperTest.java
+++ b/gateway-developer-plugin/src/test/java/com/ca/apim/gateway/capublisherplugin/CAGatewayDeveloperTest.java
@@ -75,7 +75,7 @@ class CAGatewayDeveloperTest {
 
         File buildGatewayDir = new File(testProjectDir, "dist");
         Assert.assertTrue(buildGatewayDir.isDirectory());
-        File builtBundleFile = new File(buildGatewayDir, projectFolder + projectVersion + ".req.bundle");
+        File builtBundleFile = new File(buildGatewayDir, projectFolder + projectVersion + ".bundle");
         Assert.assertTrue(builtBundleFile.isFile());
     }
 
@@ -122,7 +122,7 @@ class CAGatewayDeveloperTest {
         Assert.assertTrue(buildGatewayDir.isDirectory());
         File buildGatewayBundlesDir = new File(buildGatewayDir, "bundle");
         Assert.assertTrue(buildGatewayBundlesDir.isDirectory());
-        File builtBundleFile = new File(buildGatewayBundlesDir, projectName + projectVersion + ".req.bundle");
+        File builtBundleFile = new File(buildGatewayBundlesDir, projectName + projectVersion + ".bundle");
         Assert.assertTrue(builtBundleFile.isFile());
         File gw7PackageFile = new File(buildGatewayDir, projectName + projectVersion + ".gw7");
         Assert.assertTrue(gw7PackageFile.isFile());


### PR DESCRIPTION
Fixes #104 

## Proposed Changes
* Builds bundle files with the ".bundle" extension
* Changes bundle dependency and bundle file in gw7 task to create files with ".req.bundle" extensions
*
