### PR TITLE
Referencing Authenticate by Id Prov by name instead of ID

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/IdentityProvider.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/IdentityProvider.java
@@ -6,14 +6,17 @@
 
 package com.ca.apim.gateway.cagatewayconfig.beans;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 import javax.inject.Named;
 import java.util.Map;
 
+import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_EMPTY;
 import static java.util.Arrays.stream;
 
+@JsonInclude(NON_EMPTY)
 @Named("ID_PROVIDER_CONFIG")
 public class IdentityProvider extends GatewayEntity {
 
@@ -40,6 +43,7 @@ public class IdentityProvider extends GatewayEntity {
         }
     }
 
+    private String id;
     private IdentityProviderType type;
     private Map<String,Object> properties;
 
@@ -61,6 +65,14 @@ public class IdentityProvider extends GatewayEntity {
             @JsonSubTypes.Type(value= FederatedIdentityProviderDetail.class, name="FEDERATED")
     })
     private IdentityProviderDetail identityProviderDetail;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
 
     public IdentityProviderType getType() {
         return type;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/IdentityProvider.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/IdentityProvider.java
@@ -43,7 +43,6 @@ public class IdentityProvider extends GatewayEntity {
         }
     }
 
-    private String id;
     private IdentityProviderType type;
     private Map<String,Object> properties;
 
@@ -65,14 +64,6 @@ public class IdentityProvider extends GatewayEntity {
             @JsonSubTypes.Type(value= FederatedIdentityProviderDetail.class, name="FEDERATED")
     })
     private IdentityProviderDetail identityProviderDetail;
-
-    public String getId() {
-        return id;
-    }
-
-    public void setId(String id) {
-        this.id = id;
-    }
 
     public IdentityProviderType getType() {
         return type;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IdentityProviderEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IdentityProviderEntityBuilder.java
@@ -11,13 +11,11 @@ import com.ca.apim.gateway.cagatewayconfig.beans.FederatedIdentityProviderDetail
 import com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider;
 import com.ca.apim.gateway.cagatewayconfig.beans.TrustedCert;
 import com.ca.apim.gateway.cagatewayconfig.beans.BindOnlyLdapIdentityProviderDetail;
-import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
 import org.apache.commons.collections4.CollectionUtils;
 import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
-import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.List;
 import java.util.Map;
@@ -35,11 +33,8 @@ public class IdentityProviderEntityBuilder implements EntityBuilder {
 
     private static final Integer ORDER = 1100;
     private static final String TRUSTED_CERT_URI = "http://ns.l7tech.com/2010/04/gateway-management/trustedCertificates";
-    private final IdGenerator idGenerator;
 
-    @Inject
-    IdentityProviderEntityBuilder(IdGenerator idGenerator) {
-        this.idGenerator = idGenerator;
+    IdentityProviderEntityBuilder() {
     }
 
     public List<Entity> build(Bundle bundle, BundleType bundleType, Document document) {
@@ -47,7 +42,7 @@ public class IdentityProviderEntityBuilder implements EntityBuilder {
             case DEPLOYMENT:
                 return bundle.getIdentityProviders().entrySet().stream()
                         .map(
-                                identityProviderEntry -> EntityBuilderHelper.getEntityWithOnlyMapping(ID_PROVIDER_CONFIG_TYPE, identityProviderEntry.getKey(), idGenerator.generate())
+                                identityProviderEntry -> EntityBuilderHelper.getEntityWithOnlyMapping(ID_PROVIDER_CONFIG_TYPE, identityProviderEntry.getKey(), identityProviderEntry.getValue().getId())
                         ).collect(Collectors.toList());
             case ENVIRONMENT:
                 return bundle.getIdentityProviders().entrySet().stream().map(identityProviderEntry ->
@@ -59,7 +54,7 @@ public class IdentityProviderEntityBuilder implements EntityBuilder {
     }
 
     private Entity buildIdentityProviderEntity(Bundle bundle, String name, IdentityProvider identityProvider, Document document) {
-        final String id = idGenerator.generate();
+        final String id = identityProvider.getId();
         final Element identityProviderElement = createElementWithAttribute(document, ID_PROV, ATTRIBUTE_ID, id);
         identityProviderElement.appendChild(createElementWithTextContent(document, NAME, name));
         identityProviderElement.appendChild(createElementWithTextContent(document, ID_PROV_TYPE, identityProvider.getType().getValue()));

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/config/loader/IdentityProviderLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/config/loader/IdentityProviderLoader.java
@@ -8,6 +8,7 @@ package com.ca.apim.gateway.cagatewayconfig.config.loader;
 
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider;
+import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
 import com.ca.apim.gateway.cagatewayconfig.util.json.JsonTools;
 import org.jetbrains.annotations.NotNull;
 
@@ -22,10 +23,12 @@ import java.util.Map;
 public class IdentityProviderLoader extends EntityLoaderBase<IdentityProvider> {
 
     private static final String FILE_NAME = "identity-providers";
+    private IdGenerator idGenerator;
 
     @Inject
-    IdentityProviderLoader(JsonTools jsonTools) {
+    IdentityProviderLoader(final JsonTools jsonTools, final IdGenerator idGenerator) {
         super(jsonTools);
+        this.idGenerator = idGenerator;
     }
 
     @Override
@@ -40,6 +43,7 @@ public class IdentityProviderLoader extends EntityLoaderBase<IdentityProvider> {
 
     @Override
     protected void putToBundle(Bundle bundle, @NotNull Map<String, IdentityProvider> entitiesMap) {
+        entitiesMap.values().forEach(idProv -> idProv.setId(idGenerator.generate()));
         bundle.putAllIdentityProviders(entitiesMap);
     }
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/policy/PolicyXMLElements.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/policy/PolicyXMLElements.java
@@ -11,6 +11,7 @@ package com.ca.apim.gateway.cagatewayconfig.util.policy;
  */
 public class PolicyXMLElements {
 
+    public static final String GOID_VALUE = "goidValue";
     public static final String STRING_VALUE = "stringValue";
     public static final String INCLUDE = "L7p:Include";
     public static final String ENCAPSULATED = "L7p:Encapsulated";
@@ -25,6 +26,10 @@ public class PolicyXMLElements {
     public static final String ENCAPSULATED_ASSERTION_CONFIG_NAME = "L7p:EncapsulatedAssertionConfigName";
     public static final String POLICY_GUID = "L7p:PolicyGuid";
     public static final String NO_OP_IF_CONFIG_MISSING = "L7p:NoOpIfConfigMissing";
+    public static final String AUTHENTICATION = "L7p:Authentication";
+    public static final String ID_PROV_OID = "L7p:IdentityProviderOid";
+    public static final String ID_PROV_NAME = "L7p:IdentityProviderName";
+    public static final String TARGET = "L7p:Target";
 
     private PolicyXMLElements() {
 

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IdentityProviderEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IdentityProviderEntityBuilderTest.java
@@ -13,12 +13,12 @@ import com.ca.apim.gateway.cagatewayconfig.beans.TrustedCert;
 import com.ca.apim.gateway.cagatewayconfig.beans.BindOnlyLdapIdentityProviderDetail;
 import com.ca.apim.gateway.cagatewayconfig.beans.FederatedIdentityProviderDetail;
 import com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider;
-import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
 import com.ca.apim.gateway.cagatewayconfig.util.TestUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 import org.w3c.dom.Element;
@@ -41,12 +41,19 @@ import static org.junit.jupiter.api.Assertions.*;
 class IdentityProviderEntityBuilderTest {
 
     private static final String SIMPLE_LDAP_CONFIG = "simple ldap config";
+    private static final String TEST_ID = "some id";
+    private IdentityProviderEntityBuilder builder;
+
+    @BeforeEach
+    void setUp() {
+        builder = new IdentityProviderEntityBuilder();
+    }
 
     @Test
     void buildUnsupportedIDP() {
-        final IdentityProviderEntityBuilder builder = new IdentityProviderEntityBuilder(new IdGenerator());
         final Bundle bundle = new Bundle();
         final IdentityProvider identityProvider = new IdentityProvider();
+        identityProvider.setId(TEST_ID);
         identityProvider.setType(IdentityProviderType.INTERNAL);
         bundle.putAllIdentityProviders(new HashMap<String, IdentityProvider>() {{
             put("unsupported idp", identityProvider);
@@ -56,7 +63,6 @@ class IdentityProviderEntityBuilderTest {
 
     @Test
     void buildNoIdentityProviders() {
-        final IdentityProviderEntityBuilder builder = new IdentityProviderEntityBuilder(new IdGenerator());
         final Bundle bundle = new Bundle();
         final List<Entity> identityProviderEntities = builder.build(bundle, BundleType.DEPLOYMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
         assertEquals(0, identityProviderEntities.size());
@@ -64,10 +70,10 @@ class IdentityProviderEntityBuilderTest {
 
     @Test
     void buildBindOnlyIPWithoutIPDetail() {
-        final IdentityProviderEntityBuilder builder = new IdentityProviderEntityBuilder(new IdGenerator());
         final Bundle bundle = new Bundle();
         final IdentityProvider identityProvider = new IdentityProvider();
-        identityProvider.setType(IdentityProviderType.BIND_ONLY_LDAP);
+        identityProvider.setType(BIND_ONLY_LDAP);
+        identityProvider.setId(TEST_ID);
         bundle.putAllIdentityProviders(new HashMap<String, IdentityProvider>() {{
             put("simple ldap config", identityProvider);
         }});
@@ -76,10 +82,10 @@ class IdentityProviderEntityBuilderTest {
 
     @Test
     void buildBindOnlyIPWithMissingDetails() {
-        final IdentityProviderEntityBuilder builder = new IdentityProviderEntityBuilder(new IdGenerator());
         final Bundle bundle = new Bundle();
         final IdentityProvider identityProvider = new IdentityProvider();
-        identityProvider.setType(IdentityProviderType.BIND_ONLY_LDAP);
+        identityProvider.setType(BIND_ONLY_LDAP);
+        identityProvider.setId(TEST_ID);
 
         //omit the serverUrls
         final BindOnlyLdapIdentityProviderDetail identityProviderDetail = new BindOnlyLdapIdentityProviderDetail();
@@ -96,9 +102,9 @@ class IdentityProviderEntityBuilderTest {
 
     @Test
     void buildOneBindOnlyIP() throws DocumentParseException {
-        final IdentityProviderEntityBuilder builder = new IdentityProviderEntityBuilder(new IdGenerator());
         final Bundle bundle = new Bundle();
         final IdentityProvider identityProvider = createBindOnlyLdap();
+        identityProvider.setId(TEST_ID);
         bundle.putAllIdentityProviders(new HashMap<String, IdentityProvider>() {{
             put(SIMPLE_LDAP_CONFIG, identityProvider);
         }});
@@ -138,6 +144,7 @@ class IdentityProviderEntityBuilderTest {
     @NotNull
     private static IdentityProvider createBindOnlyLdap() {
         final IdentityProvider identityProvider = new IdentityProvider();
+        identityProvider.setId(TEST_ID);
         identityProvider.setType(IdentityProvider.IdentityProviderType.BIND_ONLY_LDAP);
         identityProvider.setProperties(new HashMap<String, Object>() {{
             put("key1", "value1");
@@ -155,13 +162,13 @@ class IdentityProviderEntityBuilderTest {
 
     @Test
     void buildFedIPCertReferenceNotFound() {
-        final IdentityProviderEntityBuilder builder = new IdentityProviderEntityBuilder(new IdGenerator());
         final IdentityProvider identityProvider = new IdentityProvider();
         identityProvider.setType(IdentityProviderType.FEDERATED);
         final Set<String> certReferences = new HashSet<>(asList("cert1","cert2"));
         final FederatedIdentityProviderDetail identityProviderDetail = new FederatedIdentityProviderDetail();
         identityProviderDetail.setCertificateReferences(certReferences);
         identityProvider.setIdentityProviderDetail(identityProviderDetail);
+        identityProvider.setId(TEST_ID);
         final Bundle bundle = new Bundle();
         bundle.putAllIdentityProviders(new HashMap<String, IdentityProvider>() {{
             put("fail IDP", identityProvider);
@@ -172,11 +179,11 @@ class IdentityProviderEntityBuilderTest {
 
     @Test
     void buildFedIPMissingCertReferences() {
-        final IdentityProviderEntityBuilder builder = new IdentityProviderEntityBuilder(new IdGenerator());
         final IdentityProvider identityProvider = new IdentityProvider();
         identityProvider.setType(IdentityProvider.IdentityProviderType.FEDERATED);
         final FederatedIdentityProviderDetail identityProviderDetail = new FederatedIdentityProviderDetail();
         identityProvider.setIdentityProviderDetail(identityProviderDetail);
+        identityProvider.setId(TEST_ID);
         final Bundle bundle = new Bundle();
         bundle.putAllIdentityProviders(new HashMap<String, IdentityProvider>() {{
             put("fail IDP", identityProvider);
@@ -187,9 +194,9 @@ class IdentityProviderEntityBuilderTest {
 
     @Test
     void buildFedIPNoDetails() throws DocumentParseException {
-        final IdentityProviderEntityBuilder builder = new IdentityProviderEntityBuilder(new IdGenerator());
         final IdentityProvider identityProvider = new IdentityProvider();
-        identityProvider.setType(IdentityProviderType.FEDERATED);
+        identityProvider.setType(FEDERATED);
+        identityProvider.setId(TEST_ID);
         final Bundle bundle = new Bundle();
         bundle.putAllIdentityProviders(new HashMap<String, IdentityProvider>() {{
             put("fed IP no details", identityProvider);
@@ -205,7 +212,6 @@ class IdentityProviderEntityBuilderTest {
     @Test
     void buildOneFedIPWithCertReferences() throws DocumentParseException {
         final String FED_ID_NAME = "simple fed id with cert references";
-        final IdentityProviderEntityBuilder builder = new IdentityProviderEntityBuilder(new IdGenerator());
         final Bundle bundle = new Bundle();
         final TrustedCert cert1 = new TrustedCert();
         cert1.setId("cert1");
@@ -216,7 +222,8 @@ class IdentityProviderEntityBuilderTest {
             put("cert2", cert2);
         }});
         final IdentityProvider identityProvider = new IdentityProvider();
-        identityProvider.setType(IdentityProviderType.FEDERATED);
+        identityProvider.setType(FEDERATED);
+        identityProvider.setId(TEST_ID);
         final Set<String> certReferences = new LinkedHashSet<>(asList("cert1","cert2"));
         final FederatedIdentityProviderDetail identityProviderDetail = new FederatedIdentityProviderDetail();
         identityProviderDetail.setCertificateReferences(certReferences);
@@ -254,7 +261,7 @@ class IdentityProviderEntityBuilderTest {
     @Test
     void buildEmptyDeploymentBundle() {
         TestUtils.testDeploymentBundleWithOnlyMapping(
-                new IdentityProviderEntityBuilder(new IdGenerator()),
+                builder,
                 new Bundle(),
                 DocumentTools.INSTANCE.getDocumentBuilder().newDocument(),
                 EntityTypes.ID_PROVIDER_CONFIG_TYPE,
@@ -268,7 +275,7 @@ class IdentityProviderEntityBuilderTest {
         bundle.putAllIdentityProviders(ImmutableMap.of(SIMPLE_LDAP_CONFIG, createBindOnlyLdap()));
 
         TestUtils.testDeploymentBundleWithOnlyMapping(
-                new IdentityProviderEntityBuilder(new IdGenerator()),
+                builder,
                 bundle,
                 DocumentTools.INSTANCE.getDocumentBuilder().newDocument(),
                 EntityTypes.ID_PROVIDER_CONFIG_TYPE,

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IdentityProviderEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/IdentityProviderEntityBuilderTest.java
@@ -29,6 +29,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider.IdentityProviderType.BIND_ONLY_LDAP;
+import static com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider.IdentityProviderType.FEDERATED;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getChildElementAttributeValues;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleElement;
@@ -112,7 +114,7 @@ class IdentityProviderEntityBuilderTest {
         final List<Entity> identityProviders = builder.build(bundle, BundleType.ENVIRONMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
 
         assertEquals(1, identityProviders.size());
-        final Element identityProviderEntityXml = verifyIdProvider(identityProviders, "simple ldap config", IdentityProviderType.BIND_ONLY_LDAP);
+        final Element identityProviderEntityXml = verifyIdProvider(identityProviders, "simple ldap config", BIND_ONLY_LDAP);
         final Element idProviderProperties = getSingleElement(identityProviderEntityXml, PROPERTIES);
         final NodeList propertyList = idProviderProperties.getElementsByTagName(PROPERTY);
         assertEquals(2, propertyList.getLength());
@@ -145,7 +147,7 @@ class IdentityProviderEntityBuilderTest {
     private static IdentityProvider createBindOnlyLdap() {
         final IdentityProvider identityProvider = new IdentityProvider();
         identityProvider.setId(TEST_ID);
-        identityProvider.setType(IdentityProvider.IdentityProviderType.BIND_ONLY_LDAP);
+        identityProvider.setType(BIND_ONLY_LDAP);
         identityProvider.setProperties(new HashMap<String, Object>() {{
             put("key1", "value1");
             put("key2", "value2");
@@ -163,7 +165,7 @@ class IdentityProviderEntityBuilderTest {
     @Test
     void buildFedIPCertReferenceNotFound() {
         final IdentityProvider identityProvider = new IdentityProvider();
-        identityProvider.setType(IdentityProviderType.FEDERATED);
+        identityProvider.setType(FEDERATED);
         final Set<String> certReferences = new HashSet<>(asList("cert1","cert2"));
         final FederatedIdentityProviderDetail identityProviderDetail = new FederatedIdentityProviderDetail();
         identityProviderDetail.setCertificateReferences(certReferences);
@@ -180,7 +182,7 @@ class IdentityProviderEntityBuilderTest {
     @Test
     void buildFedIPMissingCertReferences() {
         final IdentityProvider identityProvider = new IdentityProvider();
-        identityProvider.setType(IdentityProvider.IdentityProviderType.FEDERATED);
+        identityProvider.setType(FEDERATED);
         final FederatedIdentityProviderDetail identityProviderDetail = new FederatedIdentityProviderDetail();
         identityProvider.setIdentityProviderDetail(identityProviderDetail);
         identityProvider.setId(TEST_ID);
@@ -204,7 +206,7 @@ class IdentityProviderEntityBuilderTest {
 
         final List<Entity> identityProviders = builder.build(bundle, BundleType.ENVIRONMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
 
-        Element identityProviderEntityXml = verifyIdProvider(identityProviders, "fed IP no details", IdentityProviderType.FEDERATED);
+        Element identityProviderEntityXml = verifyIdProvider(identityProviders, "fed IP no details", FEDERATED);
         //No identityProviderDetail element
         assertThrows(DocumentParseException.class, () -> getSingleElement(identityProviderEntityXml, FEDERATED_ID_PROV_DETAIL));
     }
@@ -235,7 +237,7 @@ class IdentityProviderEntityBuilderTest {
         final List<Entity> identityProviders = builder.build(bundle, BundleType.ENVIRONMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
 
         assertEquals(1, identityProviders.size());
-        final Element identityProviderEntityXml = verifyIdProvider(identityProviders, FED_ID_NAME, IdentityProviderType.FEDERATED);
+        final Element identityProviderEntityXml = verifyIdProvider(identityProviders, FED_ID_NAME, FEDERATED);
         final Element fedIdentityProviderDetailXml = getSingleElement(identityProviderEntityXml, FEDERATED_ID_PROV_DETAIL);
         final Element certRefs = getSingleElement(fedIdentityProviderDetailXml, CERTIFICATE_REFERENCES);
         final List<String> certList = getChildElementAttributeValues(certRefs, REFERENCE, ATTRIBUTE_ID);

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/config/loader/IdentityProviderLoaderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/config/loader/IdentityProviderLoaderTest.java
@@ -10,6 +10,7 @@ import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.beans.FederatedIdentityProviderDetail;
 import com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider;
 import com.ca.apim.gateway.cagatewayconfig.beans.BindOnlyLdapIdentityProviderDetail;
+import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
 import com.ca.apim.gateway.cagatewayconfig.util.file.FileUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.json.JsonTools;
 import com.ca.apim.gateway.cagatewayconfig.util.json.JsonToolsException;
@@ -39,6 +40,8 @@ class IdentityProviderLoaderTest {
 
     private TemporaryFolder rootProjectDir;
     private JsonTools jsonTools;
+    private IdGenerator idGenerator;
+    private IdentityProviderLoader identityProviderLoader;
     @Mock
     private FileUtils fileUtils;
 
@@ -46,11 +49,12 @@ class IdentityProviderLoaderTest {
     void setUp(TemporaryFolder rootProjectDir) {
         jsonTools = new JsonTools(fileUtils);
         this.rootProjectDir = rootProjectDir;
+        idGenerator = new IdGenerator();
+        identityProviderLoader = new IdentityProviderLoader(jsonTools, idGenerator);
     }
 
     @Test
     void loadBindOnlyLdapJSON() throws IOException {
-        final IdentityProviderLoader identityProviderLoader = new IdentityProviderLoader(jsonTools);
         final String json = "{\n" +
                 "  \"simple ldap\": {\n" +
                 "    \"type\" : \"BIND_ONLY_LDAP\",\n" +
@@ -82,7 +86,6 @@ class IdentityProviderLoaderTest {
 
     @Test
     void loadBindOnlyLdapYml() throws IOException {
-        final IdentityProviderLoader identityProviderLoader = new IdentityProviderLoader(jsonTools);
         final String yml = "  simple ldap:\n" +
                 "    type: BIND_ONLY_LDAP\n" +
                 "    properties:\n" +
@@ -108,7 +111,6 @@ class IdentityProviderLoaderTest {
 
     @Test
     void loadIncorrectTypeForBoolean() throws IOException {
-        final IdentityProviderLoader identityProviderLoader = new IdentityProviderLoader(jsonTools);
         final String json = "{\n" +
                 "  \"simple ldap\": {\n" +
                 "    \"type\" : \"BIND_ONLY_LDAP\",\n" +
@@ -139,7 +141,6 @@ class IdentityProviderLoaderTest {
 
     @Test
     void loadFedIdWithMultipleCertRefs() throws IOException {
-        final IdentityProviderLoader identityProviderLoader = new IdentityProviderLoader(jsonTools);
         final String yml = "fed ID:\n" +
                 "  type: FEDERATED\n" +
                 "  properties:\n" +
@@ -171,7 +172,6 @@ class IdentityProviderLoaderTest {
 
     @Test
     void loadFedIdWithNoCertRefs() throws IOException {
-        final IdentityProviderLoader identityProviderLoader = new IdentityProviderLoader(jsonTools);
         final String yml = "fed_no_cert:\n" +
                 "  type: \"FEDERATED\"\n" +
                 "  properties:\n" +

--- a/environment-creator-application/src/main/java/com/ca/apim/gateway/cagatewayconfig/BundleDetemplatizer.java
+++ b/environment-creator-application/src/main/java/com/ca/apim/gateway/cagatewayconfig/BundleDetemplatizer.java
@@ -6,7 +6,7 @@
 
 package com.ca.apim.gateway.cagatewayconfig;
 
-import com.ca.apim.gateway.cagatewayconfig.tasks.zip.beans.Bundle;
+import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 
 import java.util.Base64;
 import java.util.Map;
@@ -15,8 +15,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import static com.ca.apim.gateway.cagatewayconfig.tasks.zip.beans.IdentityProvider.INTERNAL_IDP_ID;
-import static com.ca.apim.gateway.cagatewayconfig.tasks.zip.beans.IdentityProvider.INTERNAL_IDP_NAME;
+import static com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider.INTERNAL_IDP_ID;
+import static com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider.INTERNAL_IDP_NAME;
 import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.*;
 
 public class BundleDetemplatizer {

--- a/environment-creator-application/src/main/java/com/ca/apim/gateway/cagatewayconfig/BundleDetemplatizer.java
+++ b/environment-creator-application/src/main/java/com/ca/apim/gateway/cagatewayconfig/BundleDetemplatizer.java
@@ -6,36 +6,49 @@
 
 package com.ca.apim.gateway.cagatewayconfig;
 
+import com.ca.apim.gateway.cagatewayconfig.tasks.zip.beans.Bundle;
+
 import java.util.Base64;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static com.ca.apim.gateway.cagatewayconfig.tasks.zip.beans.IdentityProvider.INTERNAL_IDP_ID;
+import static com.ca.apim.gateway.cagatewayconfig.tasks.zip.beans.IdentityProvider.INTERNAL_IDP_NAME;
+import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.*;
 
 public class BundleDetemplatizer {
 
-    private final Map<String, String> environmentVariables;
+    private final Bundle bundle;
 
-    public BundleDetemplatizer(Map<String, String> environmentVariables) {
-        this.environmentVariables = environmentVariables;
+    public BundleDetemplatizer(Bundle bundle) {
+        this.bundle = bundle;
     }
 
     public CharSequence detemplatizeBundleString(CharSequence bundleString) {
         //prefer to use string replacement instead of loading and parsing the bundle. This should perform faster and we are only replacing a limited amount of the bundle so it should be OK to do so.
+        Map<String, String> environmentVariables = bundle.getEnvironmentProperties();
 
         //Replaces variables in set context variable assertions
-        bundleString = replaceVariableInBundle(bundleString,
+        bundleString = replaceVariableInBundle(bundleString, environmentVariables,
                 "L7p:Base64Expression ENV_PARAM_NAME=\\\"ENV\\.(.+?)\\\"",
                 v -> "L7p:Base64Expression stringValue=\"" + Base64.getEncoder().encodeToString(v.getBytes()) + "\"");
 
-        //Replaces servie property variables
-        bundleString = replaceVariableInBundle(bundleString,
+        //Replaces Id prov name with goid in authentication assertions
+        bundleString = replaceVariableInBundle(bundleString, createIdProviderNameGoid(bundle),
+                ID_PROV_NAME + " " + STRING_VALUE + "=\\\"(.+?)\\\"",
+                v -> ID_PROV_OID + " " + GOID_VALUE + "=\"" + v + "\"");
+
+        //Replaces service property variables
+        bundleString = replaceVariableInBundle(bundleString, environmentVariables,
                 "l7:StringValue>SERVICE_PROPERTY_ENV\\.(.+?)<",
                 v -> "l7:StringValue>" + v + "<").toString();
         return bundleString;
     }
 
-    private StringBuffer replaceVariableInBundle(CharSequence bundle, String variableFinderRegex, Function<String, String> replacementFunction) {
+    private StringBuffer replaceVariableInBundle(CharSequence bundle, Map<String, String> mapToCheck, String variableFinderRegex, Function<String, String> replacementFunction) {
         Pattern setVariablePattern;
         Matcher setVariableMatcher;
         setVariablePattern = Pattern.compile(variableFinderRegex);
@@ -44,7 +57,7 @@ public class BundleDetemplatizer {
         StringBuffer replacedBundle = new StringBuffer();
         while (setVariableMatcher.find()) {
             String varName = setVariableMatcher.group(1);
-            String value = environmentVariables.get(varName);
+            String value = mapToCheck.get(varName);
             if (value == null) {
                 throw new BundleDetemplatizeException("Missing environment value for property: " + varName);
             }
@@ -52,5 +65,13 @@ public class BundleDetemplatizer {
         }
         setVariableMatcher.appendTail(replacedBundle);
         return replacedBundle;
+    }
+
+    private Map<String, String> createIdProviderNameGoid(Bundle bundle) {
+        Map<String, String> idProviders = bundle.getIdentityProviders().entrySet().stream().collect(Collectors.toMap(
+                Map.Entry::getKey,
+                e -> e.getValue().getId()));
+        idProviders.put(INTERNAL_IDP_NAME, INTERNAL_IDP_ID);
+        return idProviders;
     }
 }

--- a/environment-creator-application/src/main/java/com/ca/apim/gateway/cagatewayconfig/EnvironmentCreatorApplication.java
+++ b/environment-creator-application/src/main/java/com/ca/apim/gateway/cagatewayconfig/EnvironmentCreatorApplication.java
@@ -101,7 +101,7 @@ public class EnvironmentCreatorApplication {
         File[] templatizedBundles = templatizedFolder.listFiles((dir, name) -> name.endsWith(".bundle"));
         if (templatizedBundles != null) {
             BundleEnvironmentValidator bundleEnvironmentValidator = new BundleEnvironmentValidator(environmentBundle);
-            BundleDetemplatizer bundleDetemplatizer = new BundleDetemplatizer(environmentBundle.getEnvironmentProperties());
+            BundleDetemplatizer bundleDetemplatizer = new BundleDetemplatizer(environmentBundle);
             Arrays.asList(templatizedBundles)
                     .forEach(templatizedBundle -> {
                         logger.log(Level.FINE, () -> "Processing deployment bundle: " + templatizedBundle);

--- a/environment-creator-application/src/test/java/com/ca/apim/gateway/cagatewayconfig/BundleDetemplatizerTest.java
+++ b/environment-creator-application/src/test/java/com/ca/apim/gateway/cagatewayconfig/BundleDetemplatizerTest.java
@@ -6,15 +6,15 @@
 
 package com.ca.apim.gateway.cagatewayconfig;
 
-import com.ca.apim.gateway.cagatewayconfig.tasks.zip.beans.Bundle;
-import com.ca.apim.gateway.cagatewayconfig.tasks.zip.beans.IdentityProvider;
+import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
+import com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.ca.apim.gateway.cagatewayconfig.tasks.zip.beans.IdentityProvider.INTERNAL_IDP_ID;
+import static com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider.INTERNAL_IDP_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -83,13 +83,10 @@ class BundleDetemplatizerTest {
         Map<String,String> env = new HashMap<>();
         env.put("myEnvironmentVariable", "abc");
         env.put("anotherEnvVar", "qwe");
-        IdentityProvider idpTest = new IdentityProvider();
-        String testGoid = "8263a394a3782fa4984bcffc2363b8cc";
-        idpTest.setId(testGoid);
-
+        String testIdpGoid = "8263a394a3782fa4984bcffc2363b8cc";
         Bundle bundle = new Bundle();
         bundle.putAllEnvironmentProperties(env);
-        bundle.putAllIdentityProviders(ImmutableMap.of("test-IDP", idpTest));
+        bundle.putAllIdentityProviders(ImmutableMap.of("test-IDP", new IdentityProvider.Builder().id(testIdpGoid).build()));
 
         BundleDetemplatizer bundleDetemplatizer = new BundleDetemplatizer(bundle);
 
@@ -136,7 +133,7 @@ class BundleDetemplatizerTest {
                 "            &lt;L7p:Target target=\"RESPONSE\"/&gt;\n" +
                 "        &lt;/L7p:Authentication&gt;\n" +
                 "        &lt;L7p:Authentication&gt;\n" +
-                "            &lt;L7p:IdentityProviderOid goidValue=\"" + testGoid + "\"/&gt;\n" +
+                "            &lt;L7p:IdentityProviderOid goidValue=\"" + testIdpGoid + "\"/&gt;\n" +
                 "            &lt;L7p:Target target=\"RESPONSE\"/&gt;\n" +
                 "        &lt;/L7p:Authentication&gt;\n" +
                 "    &lt;/wsp:All&gt;\n" +

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/util/policy/PolicyXMLSimplifierTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/util/policy/PolicyXMLSimplifierTest.java
@@ -1,5 +1,7 @@
 package com.ca.apim.gateway.cagatewayexport.util.policy;
 
+import com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider;
+import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
@@ -9,8 +11,10 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
-import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleElement;
+import static com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider.INTERNAL_IDP_ID;
+import static com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider.INTERNAL_IDP_NAME;
 import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.*;
+import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -53,12 +57,12 @@ class PolicyXMLSimplifierTest {
     void simplifyAuthenticationAssertion() throws DocumentParseException {
         String id = new IdGenerator().generate();
         String testName = "test";
-        IdentityProviderEntity identityProviderEntity = new IdentityProviderEntity.Builder()
+        IdentityProvider identityProvider = new IdentityProvider.Builder()
                 .id(id)
                 .name(testName)
                 .build();
         Bundle bundle = new Bundle();
-        bundle.addEntity(identityProviderEntity);
+        bundle.addEntity(identityProvider);
         Element authenticationAssertion = createAuthenticationAssertionElement(id);
         policyXMLSimplifier.simplifyAuthenticationAssertion(bundle, authenticationAssertion);
 

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/util/policy/PolicyXMLSimplifierTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/util/policy/PolicyXMLSimplifierTest.java
@@ -12,15 +12,17 @@ import org.w3c.dom.NodeList;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleElement;
 import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.*;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 class PolicyXMLSimplifierTest {
+    private PolicyXMLSimplifier policyXMLSimplifier = PolicyXMLSimplifier.INSTANCE;
 
     @Test
     void simplifySetVariable() throws DocumentParseException {
         Element setVariableAssertion = createSetVariableAssertionElement("my-var", "dGVzdGluZyBzaW1wbGlmeSBzZXQgdmFyaWFibGUgYXNzZXJ0aW9u");
 
         Bundle resultantBundle = new Bundle();
-        PolicyXMLSimplifier.simplifySetVariable(setVariableAssertion, resultantBundle);
+        policyXMLSimplifier.simplifySetVariable(setVariableAssertion, resultantBundle);
 
         Element expressionElement = getSingleElement(setVariableAssertion, EXPRESSION);
         assertEquals("testing simplify set variable assertion", expressionElement.getFirstChild().getTextContent());
@@ -35,7 +37,7 @@ class PolicyXMLSimplifierTest {
         Element setVariableAssertion = createSetVariableAssertionElement("my-var2", "ew0KICAgICAgICAgICAgICAgICJlcnJvciI6ImludmFsaWRfbWV0aG9kIiwNCiAgICAgICAgICAgICAgICAiZXJyb3JfZGVzY3JpcHRpb24iOiIke3JlcXVlc3QuaHR0cC5tZXRob2R9IG5vdCBwZXJtaXR0ZWQiDQogICAgICAgICAgICAgICAgfQ=");
 
         Bundle resultantBundle = new Bundle();
-        PolicyXMLSimplifier.simplifySetVariable(setVariableAssertion, resultantBundle);
+        policyXMLSimplifier.simplifySetVariable(setVariableAssertion, resultantBundle);
 
         Element expressionElement = getSingleElement(setVariableAssertion, EXPRESSION);
         assertEquals("{\r\n" +
@@ -45,6 +47,40 @@ class PolicyXMLSimplifierTest {
 
         NodeList base64ElementNodes = setVariableAssertion.getElementsByTagName(BASE_64_EXPRESSION);
         assertEquals(0, base64ElementNodes.getLength());
+    }
+
+    @Test
+    void simplifyAuthenticationAssertion() throws DocumentParseException {
+        String id = new IdGenerator().generate();
+        String testName = "test";
+        IdentityProviderEntity identityProviderEntity = new IdentityProviderEntity.Builder()
+                .id(id)
+                .name(testName)
+                .build();
+        Bundle bundle = new Bundle();
+        bundle.addEntity(identityProviderEntity);
+        Element authenticationAssertion = createAuthenticationAssertionElement(id);
+        policyXMLSimplifier.simplifyAuthenticationAssertion(bundle, authenticationAssertion);
+
+        assertEquals(testName, getSingleChildElementAttribute(authenticationAssertion, ID_PROV_NAME, STRING_VALUE));
+        assertNull(getSingleChildElement(authenticationAssertion, ID_PROV_OID, true));
+    }
+
+    @Test
+    void simplifyAuthenticationAssertionToInternalIDP() throws DocumentParseException {
+        Element authenticationAssertion = createAuthenticationAssertionElement(INTERNAL_IDP_ID);
+        policyXMLSimplifier.simplifyAuthenticationAssertion(new Bundle(), authenticationAssertion);
+        assertEquals(INTERNAL_IDP_NAME, getSingleChildElementAttribute(authenticationAssertion, ID_PROV_NAME, STRING_VALUE));
+        assertNull(getSingleChildElement(authenticationAssertion, ID_PROV_OID, true));
+    }
+
+    @Test
+    void simplifyAuthenticationAssertionToMissingIDP() throws DocumentParseException {
+        String id = new IdGenerator().generate();
+        Element authenticationAssertion = createAuthenticationAssertionElement(id);
+        policyXMLSimplifier.simplifyAuthenticationAssertion(new Bundle(), authenticationAssertion);
+        assertEquals(id, getSingleChildElementAttribute(authenticationAssertion, ID_PROV_OID, GOID_VALUE));
+        assertNull(getSingleChildElement(authenticationAssertion, ID_PROV_NAME, true));
     }
 
     @NotNull
@@ -63,5 +99,15 @@ class PolicyXMLSimplifierTest {
         setVariableAssertion.appendChild(variableToSetElement);
         variableToSetElement.setAttribute(STRING_VALUE, variableName);
         return setVariableAssertion;
+    }
+
+    @NotNull private Element createAuthenticationAssertionElement(String id) {
+        Document document = DocumentTools.INSTANCE.getDocumentBuilder().newDocument();
+        return createElementWithChildren(
+                document,
+                AUTHENTICATION,
+                createElementWithAttribute(document, ID_PROV_OID, GOID_VALUE, id),
+                createElementWithAttribute(document, TARGET, "target", "RESPONSE")
+        );
     }
 }


### PR DESCRIPTION
Fixes #113

## Proposed Changes
```xml
<L7p:Authentication>
    <L7p:IdentityProviderName stringValue="My-IDP"/>
</L7p:Authentication>
```
* translates the old L7p:IdentityProviderOid tag to the format above during export
* translates to the format above from the old L7p:IdentityProviderOid tag during build
* Added unit tests

Side note: other assertions that reference Identity providers are Authenticate Against Group and Authenticate Against User assertions. But those also require User and Group entity support, I've added those tickets to the backlog to be prioritized and finished when needed