### PR TITLE
removing policy extension when referencing policy

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/PolicyLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/PolicyLoader.java
@@ -78,7 +78,7 @@ public class PolicyLoader implements BundleEntityLoader {
     }
 
     private String getPath(Folder parentFolder, String name) {
-        return Paths.get(parentFolder.getPath()).resolve(name + ".xml").toString();
+        return Paths.get(parentFolder.getPath()).resolve(name).toString();
     }
 
     private Folder getFolder(Bundle bundle, String folderId) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/config/loader/PolicyAndFolderLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/config/loader/PolicyAndFolderLoader.java
@@ -62,8 +62,10 @@ public class PolicyAndFolderLoader implements EntityLoader {
     }
 
     private Policy loadPolicy(final File policyFile, final File rootDir, Folder parentFolder) {
+        String policyPath = FolderLoaderUtils.getPath(policyFile, rootDir);
+
         Policy policy = new Policy();
-        policy.setPath(FolderLoaderUtils.getPath(policyFile, rootDir));
+        policy.setPath(policyPath.substring(0, policyPath.length() - ".xml".length()));
         policy.setPolicyXML(fileUtils.getFileAsString(policyFile));
         policy.setName(getPolicyName(policyFile));
         policy.setParentFolder(parentFolder);

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/PolicyLoaderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/PolicyLoaderTest.java
@@ -54,7 +54,7 @@ class PolicyLoaderTest {
         assertFalse(bundle.getPolicies().isEmpty());
         assertEquals(1, bundle.getPolicies().size());
 
-        String path = Paths.get(TEST_FOLDER_1, TEST_POLICY_NAME + ".xml").toString();
+        String path = Paths.get(TEST_FOLDER_1, TEST_POLICY_NAME).toString();
         Policy policy = bundle.getPolicies().get(path);
         assertNotNull(policy);
         assertEquals(TEST_POLICY_ID, policy.getId());

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/config/loader/AuditPolicyLoaderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/config/loader/AuditPolicyLoaderTest.java
@@ -17,8 +17,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.Extensions;
-import org.mockito.*;
-import org.mockito.junit.jupiter.*;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.testcontainers.shaded.com.google.common.io.Files;
 
 import java.io.ByteArrayInputStream;
@@ -28,7 +28,7 @@ import java.nio.file.Paths;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
 @Extensions({ @ExtendWith(MockitoExtension.class), @ExtendWith(TemporaryFolderExtension.class) })
 class AuditPolicyLoaderTest {
@@ -49,7 +49,7 @@ class AuditPolicyLoaderTest {
     @Test
     void loadYaml() throws IOException {
         String yaml = "'" + NAME + "':\n" +
-                "  path: \"gateway-solution/audit-policies/" + NAME + ".xml\"\n" +
+                "  path: \"gateway-solution/audit-policies/" + NAME + "\"\n" +
                 "  tag: \"audit-sink\"";
         load(yaml, "yml", null);
     }
@@ -58,7 +58,7 @@ class AuditPolicyLoaderTest {
     void loadJson() throws IOException {
         String json = "{\n" +
                 "  \"" + NAME + "\": {\n" +
-                "    \"path\": \"gateway-solution/audit-policies/" + NAME + ".xml\",\n" +
+                "    \"path\": \"gateway-solution/audit-policies/" + NAME + "\",\n" +
                 "    \"tag\": \"audit-sink\"\n" +
                 "  }\n" +
                 "}";
@@ -68,7 +68,7 @@ class AuditPolicyLoaderTest {
     @Test
     void loadMalformedYaml() throws IOException {
         String yaml = "'" + NAME + "':\n" +
-                "  path \"gateway-solution/audit-policies/" + NAME + ".xml\"\n" +
+                "  path \"gateway-solution/audit-policies/" + NAME + "\"\n" +
                 "  tag \"audit-sink\"";
         load(yaml, "yml", JsonToolsException.class);
     }
@@ -77,7 +77,7 @@ class AuditPolicyLoaderTest {
     void loadMalformedJson() throws IOException {
         String json = "{\n" +
                 "  \"" + NAME + "\": {\n" +
-                "    \"path\": \"gateway-solution/audit-policies/" + NAME + ".xml\",\n" +
+                "    \"path\": \"gateway-solution/audit-policies/" + NAME + "\",\n" +
                 "    \"tag\": \"audit-sink\"\n" +
                 "  \n" +
                 "";
@@ -87,10 +87,10 @@ class AuditPolicyLoaderTest {
     @Test
     void loadRepeatedTag() throws IOException {
         String yaml = "'[Internal Audit Sink Policy]':\n" +
-                "  path: \"gateway-solution/audit-policies/[Internal Audit Sink Policy].xml\"\n" +
+                "  path: \"gateway-solution/audit-policies/[Internal Audit Sink Policy]\"\n" +
                 "  tag: \"audit-sink\"\n" +
                 "'[Internal Audit Sink Policy 1]':\n" +
-                "  path: \"gateway-solution/audit-policies/[Internal Audit Sink Policy 1].xml\"\n" +
+                "  path: \"gateway-solution/audit-policies/[Internal Audit Sink Policy 1]\"\n" +
                 "  tag: \"audit-sink\"";
         load(yaml, "yml", ConfigLoadException.class);
     }
@@ -121,7 +121,7 @@ class AuditPolicyLoaderTest {
         assertFalse(bundle.getPolicies().isEmpty());
         assertEquals(1, bundle.getPolicies().size());
 
-        String policyPath = Paths.get("gateway-solution", "audit-policies", NAME + ".xml").toString();
+        String policyPath = Paths.get("gateway-solution", "audit-policies", NAME).toString();
         assertNotNull(bundle.getPolicies().get(policyPath));
 
         Policy policy = bundle.getPolicies().get(policyPath);

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/config/loader/GlobalPolicyLoaderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/config/loader/GlobalPolicyLoaderTest.java
@@ -17,8 +17,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.Extensions;
-import org.mockito.*;
-import org.mockito.junit.jupiter.*;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.testcontainers.shaded.com.google.common.io.Files;
 
 import java.io.ByteArrayInputStream;
@@ -49,7 +49,7 @@ class GlobalPolicyLoaderTest {
     @Test
     void loadYaml() throws IOException {
         String yaml = "'" + NAME + "':\n" +
-                "  path: \"gateway-solution/global-policies/" + NAME + ".xml\"\n" +
+                "  path: \"gateway-solution/global-policies/" + NAME + "\"\n" +
                 "  tag: \"message-completed\"";
         load(yaml, "yml", null);
     }
@@ -58,7 +58,7 @@ class GlobalPolicyLoaderTest {
     void loadJson() throws IOException {
         String json = "{\n" +
                 "  \"" + NAME + "\": {\n" +
-                "    \"path\": \"gateway-solution/global-policies/" + NAME + ".xml\",\n" +
+                "    \"path\": \"gateway-solution/global-policies/" + NAME + "\",\n" +
                 "    \"tag\": \"message-completed\"\n" +
                 "  }\n" +
                 "}";
@@ -68,7 +68,7 @@ class GlobalPolicyLoaderTest {
     @Test
     void loadMalformedYaml() throws IOException {
         String yaml = "'" + NAME + "':\n" +
-                "  path \"gateway-solution/global-policies/" + NAME + ".xml\"\n" +
+                "  path \"gateway-solution/global-policies/" + NAME + "\"\n" +
                 "  tag \"message-completed\"";
         load(yaml, "yml", JsonToolsException.class);
     }
@@ -77,7 +77,7 @@ class GlobalPolicyLoaderTest {
     void loadMalformedJson() throws IOException {
         String json = "{\n" +
                 "  \"" + NAME + "\": {\n" +
-                "    \"path\": \"gateway-solution/global-policies/" + NAME + ".xml\",\n" +
+                "    \"path\": \"gateway-solution/global-policies/" + NAME + "\",\n" +
                 "    \"tag\": \"message-completed\"\n" +
                 "  \n" +
                 "";
@@ -87,10 +87,10 @@ class GlobalPolicyLoaderTest {
     @Test
     void loadRepeatedTag() throws IOException {
         String yaml = "global-completed-policy:\n" +
-                "  path: \"gateway-solution/global-policies/global-completed-policy.xml\"\n" +
+                "  path: \"gateway-solution/global-policies/global-completed-policy\"\n" +
                 "  tag: \"message-completed\"\n" +
                 "global-completed-policy-2:\n" +
-                "  path: \"gateway-solution/global-policies/global-completed-policy-2.xml\"\n" +
+                "  path: \"gateway-solution/global-policies/global-completed-policy-2\"\n" +
                 "  tag: \"message-completed\"";
         load(yaml, "yml", ConfigLoadException.class);
     }
@@ -121,8 +121,8 @@ class GlobalPolicyLoaderTest {
     private static void check(Bundle bundle) {
         assertFalse(bundle.getPolicies().isEmpty());
         assertEquals(1, bundle.getPolicies().size());
-        
-        String policyPath = Paths.get("gateway-solution", "global-policies", NAME + ".xml").toString();
+
+        String policyPath = Paths.get("gateway-solution", "global-policies", NAME).toString();
         assertNotNull(bundle.getPolicies().get(policyPath));
 
         Policy policy = bundle.getPolicies().get(policyPath);

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/config/loader/PolicyAndFolderLoaderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/config/loader/PolicyAndFolderLoaderTest.java
@@ -75,7 +75,7 @@ class PolicyAndFolderLoaderTest {
         Folder parentFolder = bundle.getFolders().get("a/b/c/");
         Assert.assertNotNull(parentFolder);
 
-        Policy loadedPolicy = bundle.getPolicies().get("a/b/c/policy.xml");
+        Policy loadedPolicy = bundle.getPolicies().get("a/b/c/policy");
         Assert.assertNotNull(loadedPolicy);
         Assert.assertEquals(parentFolder, loadedPolicy.getParentFolder());
     }

--- a/gateway-developer-plugin/src/test/resources/example-project-custom-organization/export/gateway/solution/config/services.yml
+++ b/gateway-developer-plugin/src/test/resources/example-project-custom-organization/export/gateway/solution/config/services.yml
@@ -1,5 +1,5 @@
 example project/example:
-  policy: "example project/example.xml"
+  policy: "example project/example"
   httpMethods:
   - GET
   - POST
@@ -7,7 +7,7 @@ example project/example:
   - DELETE
   url: "/example"
 example project/example-project:
-  policy: "example project/example-project.xml"
+  policy: "example project/example-project"
   httpMethods:
   - POST
   - PUT

--- a/gateway-developer-plugin/src/test/resources/example-project/src/main/gateway/config/encass.yml
+++ b/gateway-developer-plugin/src/test/resources/example-project/src/main/gateway/config/encass.yml
@@ -1,5 +1,5 @@
 encass-policy:
-  policy: example project/encass-policy.xml
+  policy: example project/encass-policy
   arguments:
   - name: "hello"
     type: "string"
@@ -11,7 +11,7 @@ encass-policy:
   - name: "goodbye-again"
     type: "message"
 encass-policy-same-policy:
-  policy: example project/encass-policy.xml
+  policy: example project/encass-policy
   arguments:
   - name: "hello"
     type: "string"
@@ -23,7 +23,7 @@ encass-policy-same-policy:
   - name: "goodbye-again"
     type: "message"
 example-_¯-¯_-slashed:
-  policy: example project/folder-_¯-¯_-slashed/example-_¯-¯_-slashed.xml
+  policy: example project/folder-_¯-¯_-slashed/example-_¯-¯_-slashed
   arguments:
   - name: "hello"
     type: "string"

--- a/gateway-developer-plugin/src/test/resources/example-project/src/main/gateway/config/policy-backed-services.yml
+++ b/gateway-developer-plugin/src/test/resources/example-project/src/main/gateway/config/policy-backed-services.yml
@@ -1,7 +1,7 @@
 my-pbs:
   interfaceName: "com.l7tech.objectmodel.polback.BackgroundTask"
   operations:
-  - policy: "example project/example-pbs.xml"
+  - policy: "example project/example-pbs"
     operationName: "run"
-  - policy: "example project/folder-_¯-¯_-slashed/example-_¯-¯_-slashed.xml"
+  - policy: "example project/folder-_¯-¯_-slashed/example-_¯-¯_-slashed"
     operationName: "another"

--- a/gateway-developer-plugin/src/test/resources/example-project/src/main/gateway/config/services.yml
+++ b/gateway-developer-plugin/src/test/resources/example-project/src/main/gateway/config/services.yml
@@ -1,5 +1,5 @@
 example project/example:
-  policy: "example project/example.xml"
+  policy: "example project/example"
   httpMethods:
   - GET
   - POST
@@ -7,7 +7,7 @@ example project/example:
   - DELETE
   url: "/example"
 example project/example-project:
-  policy: "example project/example-project.xml"
+  policy: "example project/example-project"
   httpMethods:
   - POST
   - PUT
@@ -16,7 +16,7 @@ example project/example-project:
     key: "value"
     key.1: "value.1"
 example project/_¯example_¯policy_¯slash:
-  policy: "example project/_¯example_¯policy_¯slash.xml"
+  policy: "example project/_¯example_¯policy_¯slash"
   httpMethods:
   - GET
   - POST

--- a/gateway-developer-plugin/src/test/resources/example-project/src/main/gateway/policy/example project/example-pbs.xml
+++ b/gateway-developer-plugin/src/test/resources/example-project/src/main/gateway/policy/example project/example-pbs.xml
@@ -10,7 +10,7 @@
             <L7p:Comment stringValue="Policy Fragment: my-pbs"/>
         </L7p:CommentAssertion>
         <L7p:Include>
-            <L7p:PolicyGuid policyPath="another/some other.xml"/>
+            <L7p:PolicyGuid policyPath="another/some other"/>
         </L7p:Include>
     </wsp:All>
 </wsp:Policy>

--- a/gateway-developer-plugin/src/test/resources/example-project/src/main/gateway/policy/example project/example-policy-include.xml
+++ b/gateway-developer-plugin/src/test/resources/example-project/src/main/gateway/policy/example project/example-policy-include.xml
@@ -27,7 +27,7 @@
             </L7p:Parameters>
         </L7p:Encapsulated>
         <L7p:Include>
-            <L7p:PolicyGuid policyPath="example project/encass-policy.xml"/>
+            <L7p:PolicyGuid policyPath="example project/encass-policy"/>
         </L7p:Include>
     </wsp:All>
 </wsp:Policy>

--- a/gateway-developer-plugin/src/test/resources/multi-project/project-a/src/main/gateway/policy/common/dependent.xml
+++ b/gateway-developer-plugin/src/test/resources/multi-project/project-a/src/main/gateway/policy/common/dependent.xml
@@ -7,7 +7,7 @@
 <wsp:Policy xmlns:wsp="http://schemas.xmlsoap.org/ws/2002/12/policy" xmlns:L7p="http://www.layer7tech.com/ws/policy">
     <wsp:All wsp:Usage="Required">
         <L7p:Include>
-            <L7p:PolicyGuid policyPath="common/my-common-policy.xml"/>
+            <L7p:PolicyGuid policyPath="common/my-common-policy"/>
         </L7p:Include>
     </wsp:All>
 </wsp:Policy>

--- a/gateway-developer-plugin/src/test/resources/multi-project/project-d/src/main/gateway/policy/common/dependent.xml
+++ b/gateway-developer-plugin/src/test/resources/multi-project/project-d/src/main/gateway/policy/common/dependent.xml
@@ -7,7 +7,7 @@
 <wsp:Policy xmlns:wsp="http://schemas.xmlsoap.org/ws/2002/12/policy" xmlns:L7p="http://www.layer7tech.com/ws/policy">
     <wsp:All wsp:Usage="Required">
         <L7p:Include>
-            <L7p:PolicyGuid policyPath="common/my-common-policy.xml"/>
+            <L7p:PolicyGuid policyPath="common/my-common-policy"/>
         </L7p:Include>
     </wsp:All>
 </wsp:Policy>

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/PolicyLinker.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/PolicyLinker.java
@@ -63,6 +63,6 @@ public class PolicyLinker implements EntityLinker<Policy> {
                     policy.getParentFolder().getId()));
         }
         Path folderPath = bundle.getFolderTree().getPath(folder);
-        return Paths.get(folderPath.toString(), policy.getName() + ".xml").toString();
+        return Paths.get(folderPath.toString(), policy.getName()).toString();
     }
 }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/PolicyWriter.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/PolicyWriter.java
@@ -55,7 +55,7 @@ public class PolicyWriter implements EntityWriter {
         Path folderPath = policyFolder.toPath().resolve(bundle.getFolderTree().getPath(folder));
         documentFileUtils.createFolders(folderPath);
 
-        Path policyPath = folderPath.resolve(name + ".xml");
+        Path policyPath = folderPath.resolve(name);
         documentFileUtils.createFile(policy, policyPath, false);
     }
 }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/ServiceWriter.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/ServiceWriter.java
@@ -53,7 +53,7 @@ public class ServiceWriter implements EntityWriter {
     @NotNull
     private Service getServiceBean(Service serviceEntity) {
         Service serviceBean = new Service();
-        serviceBean.setPolicy(serviceEntity.getPath() + ".xml");
+        serviceBean.setPolicy(serviceEntity.getPath());
         Element serviceMappingsElement = getSingleChildElement(serviceEntity.getServiceDetailsElement(), SERVICE_MAPPINGS);
         Element httpMappingElement = getSingleChildElement(serviceMappingsElement, HTTP_MAPPING);
         Element urlPatternElement = getSingleChildElement(httpMappingElement, URL_PATTERN);

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/PolicyXMLSimplifier.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/PolicyXMLSimplifier.java
@@ -28,9 +28,9 @@ import java.util.logging.Logger;
 
 import static com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider.INTERNAL_IDP_ID;
 import static com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider.INTERNAL_IDP_NAME;
+import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.createElementWithAttribute;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleElement;
-import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.*;
 
 public class PolicyXMLSimplifier {
     public static final PolicyXMLSimplifier INSTANCE = new PolicyXMLSimplifier();
@@ -190,6 +190,6 @@ public class PolicyXMLSimplifier {
     private String getPolicyPath(Bundle bundle, Policy policyEntity) {
         Folder folder = bundle.getFolderTree().getFolderById(policyEntity.getParentFolder().getId());
         Path folderPath = bundle.getFolderTree().getPath(folder);
-        return Paths.get(folderPath.toString(), policyEntity.getName() + ".xml").toString();
+        return Paths.get(folderPath.toString(), policyEntity.getName()).toString();
     }
 }

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinkerTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinkerTest.java
@@ -43,7 +43,7 @@ class EncassLinkerTest {
 
         encassLinker.link(bundle, fullBundle);
 
-        assertEquals("myEncassPolicy.xml", bundle.getEntities(Encass.class).get("1").getPath());
+        assertEquals("myEncassPolicy", bundle.getEntities(Encass.class).get("1").getPath());
     }
 
     @Test

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/PolicyBackedServiceLinkerTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/PolicyBackedServiceLinkerTest.java
@@ -14,7 +14,8 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static com.ca.apim.gateway.cagatewayexport.util.TestUtils.*;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class PolicyBackedServiceLinkerTest {
 
@@ -41,8 +42,8 @@ class PolicyBackedServiceLinkerTest {
 
         policyBackedServiceLinker.link(bundle, fullBundle);
 
-        assertEquals("operation1Policy.xml", bundle.getEntities(PolicyBackedService.class).get("1").getOperations().stream().collect(Collectors.toMap(PolicyBackedServiceOperation::getOperationName, PolicyBackedServiceOperation::getPolicy)).get("operation1"));
-        assertEquals("operation2Policy.xml", bundle.getEntities(PolicyBackedService.class).get("1").getOperations().stream().collect(Collectors.toMap(PolicyBackedServiceOperation::getOperationName, PolicyBackedServiceOperation::getPolicy)).get("operation2"));
+        assertEquals("operation1Policy", bundle.getEntities(PolicyBackedService.class).get("1").getOperations().stream().collect(Collectors.toMap(PolicyBackedServiceOperation::getOperationName, PolicyBackedServiceOperation::getPolicy)).get("operation1"));
+        assertEquals("operation2Policy", bundle.getEntities(PolicyBackedService.class).get("1").getOperations().stream().collect(Collectors.toMap(PolicyBackedServiceOperation::getOperationName, PolicyBackedServiceOperation::getPolicy)).get("operation2"));
     }
 
     @Test

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ScheduledTaskLinkerTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ScheduledTaskLinkerTest.java
@@ -51,7 +51,7 @@ class ScheduledTaskLinkerTest {
         fullBundle.setFolderTree(folderTree);
 
         scheduledTaskLinker.link(bundle, fullBundle);
-        assertEquals("myScheduledPolicy.xml", bundle.getEntities(ScheduledTask.class).get("1").getPolicy());
+        assertEquals("myScheduledPolicy", bundle.getEntities(ScheduledTask.class).get("1").getPolicy());
     }
 
     @Test

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/AuditPolicyWriterTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/AuditPolicyWriterTest.java
@@ -69,7 +69,7 @@ class AuditPolicyWriterTest {
 
     @Test
     void testGetAuditPolicyBean() {
-        String path = Paths.get(TEST_FOLDER_1, TEST_POLICY_NAME + ".xml").toString();
+        String path = Paths.get(TEST_FOLDER_1, TEST_POLICY_NAME).toString();
         Policy auditPolicy = new Policy.Builder()
                 .setName(TEST_POLICY_NAME)
                 .setId(TEST_POLICY_ID)

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/GlobalPolicyWriterTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/GlobalPolicyWriterTest.java
@@ -69,7 +69,7 @@ class GlobalPolicyWriterTest {
 
     @Test
     void testGetGlobalPolicyBean() {
-        String path = Paths.get(TEST_FOLDER_1, TEST_POLICY_NAME + ".xml").toString();
+        String path = Paths.get(TEST_FOLDER_1, TEST_POLICY_NAME).toString();
         Policy globalPolicy = new Policy.Builder()
                 .setName(TEST_POLICY_NAME)
                 .setId(TEST_POLICY_ID)


### PR DESCRIPTION
relates to #111 and #102 

## Proposed Changes
* Removes the `.xml` extension when referencing policies
* This enables multiple policy types in the future