### PR TITLE
saving policy files with .xml extension

### DIFF
--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/PolicyWriter.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/writer/PolicyWriter.java
@@ -55,7 +55,7 @@ public class PolicyWriter implements EntityWriter {
         Path folderPath = policyFolder.toPath().resolve(bundle.getFolderTree().getPath(folder));
         documentFileUtils.createFolders(folderPath);
 
-        Path policyPath = folderPath.resolve(name);
+        Path policyPath = folderPath.resolve(name + ".xml");
         documentFileUtils.createFile(policy, policyPath, false);
     }
 }


### PR DESCRIPTION
## Proposed Changes
* adds the `.xml` extension when saving policy files during export
