### PR TITLE
Using BC as a provider for cert util tests

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/gateway/CertificateUtils.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/gateway/CertificateUtils.java
@@ -52,10 +52,14 @@ public class CertificateUtils {
         } catch (CertificateException e) {
             throw new CertificateUtilsException("Error generating certificate from file", e);
         }
+        //Using BC as a provider will return null for an inputStream of faulty bytes
+        if (cert == null) {
+            throw new CertificateUtilsException("Error generating certificate from file.");
+        }
         return cert;
     }
 
-    public static Element createCertDataElementFromCert(X509Certificate cert, Document document) {
+    public static Element createCertDataElementFromCert(@NotNull X509Certificate cert, Document document) {
         try {
             return createCertDataElementFromCert(
                     cert.getIssuerDN().getName(),

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/gateway/CertificateUtilsTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/gateway/CertificateUtilsTest.java
@@ -35,7 +35,7 @@ class CertificateUtilsTest {
 
     @BeforeAll
     static void beforeAll() {
-        Security.addProvider(new BouncyCastleProvider());
+        Security.insertProviderAt(new BouncyCastleProvider(), 1);
     }
 
     @BeforeEach
@@ -50,7 +50,7 @@ class CertificateUtilsTest {
                 () -> buildCertDataFromFile(
                         () -> Files.newInputStream(Paths.get(rootProjectDir.getRoot().toPath().toString(), "cert.cert")),
                         DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument(),
-                        CertificateFactory.getInstance("X.509", "BC")
+                        CertificateFactory.getInstance("X.509")
                 )
         );
     }
@@ -62,7 +62,7 @@ class CertificateUtilsTest {
                 () -> buildCertDataFromFile(
                         () -> new ByteArrayInputStream("certificate".getBytes()),
                         DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument(),
-                        CertificateFactory.getInstance("X.509", "BC")
+                        CertificateFactory.getInstance("X.509")
                 )
         );
     }

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/gateway/CertificateUtilsTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/gateway/CertificateUtilsTest.java
@@ -9,6 +9,8 @@ package com.ca.apim.gateway.cagatewayconfig.util.gateway;
 import io.github.glytching.junit.extension.folder.TemporaryFolder;
 import io.github.glytching.junit.extension.folder.TemporaryFolderExtension;
 import org.apache.commons.io.FileUtils;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,9 +20,9 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.security.Security;
 import java.security.cert.CertificateFactory;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.CertificateUtils.*;
@@ -30,6 +32,12 @@ import static org.junit.jupiter.api.Assertions.*;
 class CertificateUtilsTest {
 
     private TemporaryFolder rootProjectDir;
+
+    @BeforeAll
+    static void beforeAll() {
+        Security.addProvider(new BouncyCastleProvider());
+    }
+
     @BeforeEach
     void setUp(final TemporaryFolder temporaryFolder) {
         rootProjectDir = temporaryFolder;
@@ -42,7 +50,7 @@ class CertificateUtilsTest {
                 () -> buildCertDataFromFile(
                         () -> Files.newInputStream(Paths.get(rootProjectDir.getRoot().toPath().toString(), "cert.cert")),
                         DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument(),
-                        CertificateFactory.getInstance("X.509")
+                        CertificateFactory.getInstance("X.509", "BC")
                 )
         );
     }
@@ -54,7 +62,7 @@ class CertificateUtilsTest {
                 () -> buildCertDataFromFile(
                         () -> new ByteArrayInputStream("certificate".getBytes()),
                         DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument(),
-                        CertificateFactory.getInstance("X.509")
+                        CertificateFactory.getInstance("X.509", "BC")
                 )
         );
     }


### PR DESCRIPTION
Quick fix to use BC as a provider for cert utils test. I looked into removing BC after KeystoreHelper creates the keystore and loads keys, but found that it affected other tests/areas of code. Decided to set BC as the provider for running the CertificateUtilsTest.
