### PR TITLE
Revert changes to fix build issues when using the plugin

### DIFF
--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/export/GatewayConnectionProperties.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/export/GatewayConnectionProperties.java
@@ -14,13 +14,11 @@ public class GatewayConnectionProperties {
     private Property<String> url;
     private Property<String> userName;
     private Property<String> userPass;
-    private Property<String> folderPath;
 
     public GatewayConnectionProperties(Project project) {
         url = project.getObjects().property(String.class);
         userName = project.getObjects().property(String.class);
         userPass = project.getObjects().property(String.class);
-        folderPath = project.getObjects().property(String.class);
     }
 
     /**
@@ -52,15 +50,4 @@ public class GatewayConnectionProperties {
     public Property<String> getUserPass() {
         return userPass;
     }
-
-    /**
-     * The path of the folder to export.
-     *
-     * @return the folder to export from the gateway
-     */
-    @Input
-    public Property<String> getFolderPath() {
-        return folderPath;
-    }
-
 }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/export/GatewayConnectionProperties.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/export/GatewayConnectionProperties.java
@@ -14,11 +14,13 @@ public class GatewayConnectionProperties {
     private Property<String> url;
     private Property<String> userName;
     private Property<String> userPass;
+    private Property<String> folderPath;
 
-    GatewayConnectionProperties(Project project) {
+    public GatewayConnectionProperties(Project project) {
         url = project.getObjects().property(String.class);
         userName = project.getObjects().property(String.class);
         userPass = project.getObjects().property(String.class);
+        folderPath = project.getObjects().property(String.class);
     }
 
     /**
@@ -50,4 +52,15 @@ public class GatewayConnectionProperties {
     public Property<String> getUserPass() {
         return userPass;
     }
+
+    /**
+     * The path of the folder to export.
+     *
+     * @return the folder to export from the gateway
+     */
+    @Input
+    public Property<String> getFolderPath() {
+        return folderPath;
+    }
+
 }


### PR DESCRIPTION
Fixing this error message when building on gateway-developer-example.

Failed to apply plugin [id 'com.ca.apim.gateway.gateway-export-plugin']
Could not create an instance of type com.ca.apim.gateway.cagatewayexport.tasks.export.GatewayConnectionProperties_Decorated.
Could not find any public constructor for class com.ca.apim.gateway.cagatewayexport.tasks.export.GatewayConnectionProperties_Decorated which accepts parameters [org.gradle.api.internal.project.DefaultProject_Decorated].