### PR TITLE
Adding support to link listen ports with private keys

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/ListenPort.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/ListenPort.java
@@ -33,6 +33,8 @@ public class ListenPort extends GatewayEntity {
 
     public static final String PROTOCOL_HTTP = "HTTP";
     public static final String PROTOCOL_HTTPS = "HTTPS";
+    public static final String PROTOCOL_FTP = "FTP";
+    public static final String PROTOCOL_FTPS = "FTPS";
     public static final Integer HTTP_DEFAULT_PORT = 8080;
     public static final Integer HTTPS_DEFAULT_PORT = 8443;
     public static final String DEFAULT_HTTP_8080 = "Default HTTP (8080)";
@@ -152,6 +154,7 @@ public class ListenPort extends GatewayEntity {
         public static final String TLSV12 = "TLSv1.2";
 
         private ClientAuthentication clientAuthentication;
+        private String privateKey;
         private Set<String> enabledVersions;
         private Set<String> enabledCipherSuites;
         private Map<String, Object> properties;
@@ -162,6 +165,14 @@ public class ListenPort extends GatewayEntity {
 
         public void setClientAuthentication(ClientAuthentication clientAuthentication) {
             this.clientAuthentication = clientAuthentication;
+        }
+
+        public String getPrivateKey() {
+            return privateKey;
+        }
+
+        public void setPrivateKey(String privateKey) {
+            this.privateKey = privateKey;
         }
 
         public Set<String> getEnabledVersions() {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ListenPortEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ListenPortEntityBuilder.java
@@ -13,14 +13,16 @@ import com.ca.apim.gateway.cagatewayconfig.beans.ListenPort.ListenPortTlsSetting
 import com.ca.apim.gateway.cagatewayconfig.beans.PrivateKey;
 import com.ca.apim.gateway.cagatewayconfig.beans.Service;
 import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.util.*;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes.LISTEN_PORT_TYPE;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ListenPortEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ListenPortEntityBuilder.java
@@ -10,8 +10,10 @@ import com.ca.apim.gateway.cagatewayconfig.beans.ListenPort;
 import com.ca.apim.gateway.cagatewayconfig.beans.ListenPort.ClientAuthentication;
 import com.ca.apim.gateway.cagatewayconfig.beans.ListenPort.Feature;
 import com.ca.apim.gateway.cagatewayconfig.beans.ListenPort.ListenPortTlsSettings;
+import com.ca.apim.gateway.cagatewayconfig.beans.PrivateKey;
 import com.ca.apim.gateway.cagatewayconfig.beans.Service;
 import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -33,6 +35,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.concat;
 import static org.apache.commons.collections4.CollectionUtils.isNotEmpty;
 import static org.apache.commons.collections4.MapUtils.unmodifiableMap;
+import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
 /**
  * Builder for Listen ports
@@ -42,7 +45,7 @@ public class ListenPortEntityBuilder implements EntityBuilder {
 
     private static final Map<String, ListenPort> DEFAULT_PORTS = unmodifiableMap(createDefaultListenPorts());
     private static final String USES_TLS = "usesTLS";
-    private static final Integer ORDER = 800;
+    private static final Integer ORDER = 1200;
 
     private final IdGenerator idGenerator;
 
@@ -100,6 +103,14 @@ public class ListenPortEntityBuilder implements EntityBuilder {
 
             Element tlsSettingsElement = document.createElement(TLS_SETTINGS);
             tlsSettingsElement.appendChild(createElementWithTextContent(document, CLIENT_AUTHENTICATION, tlsSettings.getClientAuthentication().getType()));
+
+            if (isNotEmpty(tlsSettings.getPrivateKey())) {
+                final PrivateKey privateKey = bundle.getPrivateKeys().get(tlsSettings.getPrivateKey());
+                if (privateKey == null) {
+                    throw new EntityBuilderException("Could not find Private Key " + tlsSettings.getPrivateKey() + " associated to Listen Port " + name);
+                }
+                tlsSettingsElement.appendChild(createElementWithAttribute(document, PRIVATE_KEY_REFERENCE, ATTRIBUTE_ID, privateKey.getId()));
+            }
 
             if (isNotEmpty(tlsSettings.getEnabledVersions())) {
                 Element enabledVersions = document.createElement(ENABLED_VERSIONS);

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PrivateKeyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PrivateKeyEntityBuilder.java
@@ -37,7 +37,7 @@ import static java.util.stream.Collectors.toList;
 @Singleton
 public class PrivateKeyEntityBuilder implements EntityBuilder {
 
-    private static final Integer ORDER = 1200;
+    private static final Integer ORDER = 800;
     private static final String DUMMY_CERTIFICATE = "MIIBfTCCASegAwIBAgIJAPH69zKKw4ixMA0GCSqGSIb3DQEBBQUAMA8xDTALBgNVBAMTBHRlc3QwHhcNMTgxMDEzMDMyODI1WhcNMzgxMDA4MDMyODI1WjAPMQ0wCwYDVQQDEwR0ZXN0MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAIS+Vr8zPOBmSclkUtW/z0UXaMjhg7dix6IUZs+UoSiw/2GXfU2vc3renVAbn3AZaJEqnxgrcX4nldqt0WBIP4sCAwEAAaNmMGQwDgYDVR0PAQH/BAQDAgXgMBIGA1UdJQEB/wQIMAYGBFUdJQAwHQYDVR0OBBYEFN/aeDDEAB6MTxZhMhf/eJKnmaE5MB8GA1UdIwQYMBaAFN/aeDDEAB6MTxZhMhf/eJKnmaE5MA0GCSqGSIb3DQEBBQUAA0EAdolvh7bMX5ZMkM/yntJlBdzS8ukM/ULh8I11wKd6dDltyMuk9rOP0iEk1nsSFuFL0uQ4kIe12KyDwr8ns7VKvQ==";
 
     private final KeystoreHelper keystoreHelper;
@@ -54,6 +54,7 @@ public class PrivateKeyEntityBuilder implements EntityBuilder {
 
     private Entity buildPrivateKeyEntity(String alias, PrivateKey privateKey, Document document) {
         final String id = privateKey.getKeyStoreType().generateKeyId(alias);
+        privateKey.setId(id);
         final Element privateKeyElem = createElementWithAttributes(
                 document,
                 PRIVATE_KEY,

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ListenPortLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ListenPortLoader.java
@@ -10,9 +10,6 @@ import com.ca.apim.gateway.cagatewayconfig.beans.ListenPort;
 import com.ca.apim.gateway.cagatewayconfig.beans.ListenPort.ClientAuthentication;
 import com.ca.apim.gateway.cagatewayconfig.beans.ListenPort.ListenPortTlsSettings;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
-import com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants;
-import org.apache.commons.lang3.ObjectUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Element;
 
 import javax.inject.Singleton;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ListenPortLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ListenPortLoader.java
@@ -10,6 +10,9 @@ import com.ca.apim.gateway.cagatewayconfig.beans.ListenPort;
 import com.ca.apim.gateway.cagatewayconfig.beans.ListenPort.ClientAuthentication;
 import com.ca.apim.gateway.cagatewayconfig.beans.ListenPort.ListenPortTlsSettings;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
+import com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants;
+import org.apache.commons.lang3.ObjectUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Element;
 
 import javax.inject.Singleton;
@@ -17,10 +20,14 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import static com.ca.apim.gateway.cagatewayconfig.beans.ListenPort.PROTOCOL_FTP;
+import static com.ca.apim.gateway.cagatewayconfig.beans.ListenPort.PROTOCOL_FTPS;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.mapPropertiesElements;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
+import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.USE_EXTENDED_FTP_COMMAND_SET;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.*;
 import static java.lang.Integer.parseInt;
+import static org.apache.commons.lang3.StringUtils.equalsAny;
 
 @Singleton
 public class ListenPortLoader implements BundleEntityLoader {
@@ -35,7 +42,13 @@ public class ListenPortLoader implements BundleEntityLoader {
         final Set<String> enabledFeatures = getChildElementsTextContents(getSingleChildElement(listenPortElement, ENABLED_FEATURES), STRING_VALUE);
         final String targetServiceReference = getSingleChildElementTextContent(listenPortElement, TARGET_SERVICE_REFERENCE);
         final ListenPortTlsSettings tlsSettings = getTlsSettings(listenPortElement);
-        final Map<String, Object> properties = mapPropertiesElements(getSingleChildElement(listenPortElement, PROPERTIES, true), PROPERTIES);
+        Map<String, Object> properties = mapPropertiesElements(getSingleChildElement(listenPortElement, PROPERTIES, true), PROPERTIES);
+        if (!equalsAny(protocol, PROTOCOL_FTP, PROTOCOL_FTPS)) {
+            properties.remove(USE_EXTENDED_FTP_COMMAND_SET);
+            if (properties.isEmpty()) {
+                properties = null;
+            }
+        }
 
         ListenPort listenPort = new ListenPort();
         listenPort.setId(listenPortElement.getAttribute(ATTRIBUTE_ID));
@@ -69,6 +82,8 @@ public class ListenPortLoader implements BundleEntityLoader {
 
         Element properties = getSingleChildElement(tlsSettingsElement, PROPERTIES, true);
         tlsSettings.setProperties(mapPropertiesElements(properties, PROPERTIES));
+
+        tlsSettings.setPrivateKey(getSingleChildElementAttribute(tlsSettingsElement, PRIVATE_KEY_REFERENCE, ATTRIBUTE_ID));
 
         return tlsSettings;
     }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/gateway/BundleElementNames.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/gateway/BundleElementNames.java
@@ -106,6 +106,7 @@ public class BundleElementNames {
     public static final String CLIENT_AUTHENTICATION = "l7:ClientAuthentication";
     public static final String ENABLED_VERSIONS = "l7:EnabledVersions";
     public static final String ENABLED_CIPHER_SUITES = "l7:EnabledCipherSuites";
+    public static final String PRIVATE_KEY_REFERENCE = "l7:PrivateKeyReference";
 
     // Stored Passwords
     public static final String STORED_PASSWD = "l7:StoredPassword";

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/properties/PropertyConstants.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/properties/PropertyConstants.java
@@ -16,6 +16,9 @@ public class PropertyConstants {
     public static final String PREFIX_ENV = "ENV.";
     public static final String PREFIX_PROPERTY = "property.";
 
+    // Listen Port
+    public static final String USE_EXTENDED_FTP_COMMAND_SET = "useExtendedFtpCommandSet";
+
     //Trusted Cert property constants
     public static final String VERIFY_HOSTNAME = "verifyHostname";
     public static final String TRUSTED_FOR_SSL = "trustedForSsl";

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ListenPortLoaderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ListenPortLoaderTest.java
@@ -27,8 +27,7 @@ import java.util.stream.Stream;
 import static com.ca.apim.gateway.cagatewayconfig.util.TestUtils.assertPropertiesContent;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.buildAndAppendPropertiesElement;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
-import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.createElementWithChildren;
-import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.createElementWithTextContent;
+import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.*;
 import static java.lang.Boolean.TRUE;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -54,6 +53,7 @@ class ListenPortLoaderTest {
         Assertions.assertEquals(ClientAuthentication.REQUIRED, tlsSettings.getClientAuthentication());
         assertTrue(SetUtils.isEqualSet(tlsSettings.getEnabledCipherSuites(), ListenPort.DEFAULT_RECOMMENDED_CIPHERS));
         assertTrue(SetUtils.isEqualSet(tlsSettings.getEnabledVersions(), ListenPort.TLS_VERSIONS));
+        assertEquals("Key", tlsSettings.getPrivateKey());
         assertPropertiesContent(Collections.emptyMap(), tlsSettings.getProperties());
         assertPropertiesContent(ImmutableMap.of("prop", "value"), listenPort.getProperties());
     }
@@ -103,6 +103,7 @@ class ListenPortLoaderTest {
             ListenPort.DEFAULT_RECOMMENDED_CIPHERS.forEach(s -> enabledCipherSuites.appendChild(createElementWithTextContent(document, STRING_VALUE, s)));
             tlsSettingsElement.appendChild(enabledCipherSuites);
 
+            tlsSettingsElement.appendChild(createElementWithAttribute(document, PRIVATE_KEY_REFERENCE, ATTRIBUTE_ID, "Key"));
             listenPortElement.appendChild(tlsSettingsElement);
         }
 

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/config/loader/ListenPortLoaderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/config/loader/ListenPortLoaderTest.java
@@ -64,6 +64,7 @@ class ListenPortLoaderTest {
                 "    - \"Published service message input\"\n" +
                 "    tlsSettings:\n" +
                 "      clientAuthentication: \"REQUIRED\"\n" +
+                "      privateKey: \"Key\"\n" +
                 "      enabledVersions:\n" +
                 "      - \"TLSv1.2\"\n" +
                 "      enabledCipherSuites:\n" +
@@ -86,6 +87,7 @@ class ListenPortLoaderTest {
                 "      \"enabledFeatures\" : [ \"Published service message input\" ],\n" +
                 "      \"tlsSettings\" : {\n" +
                 "        \"clientAuthentication\" : \"REQUIRED\",\n" +
+                "        \"privateKey\" : \"Key\",\n" +
                 "        \"enabledVersions\" : [ \"TLSv1.2\" ],\n" +
                 "        \"enabledCipherSuites\" : [ \"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384\", \"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384\", \"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384\" ],\n" +
                 "        \"properties\" : {\n" +
@@ -230,6 +232,7 @@ class ListenPortLoaderTest {
         assertTrue(listenPort.getTlsSettings().getEnabledVersions().contains(ListenPortTlsSettings.TLSV12), "TLS Version enabled is not 1.2");
         assertFalse(listenPort.getTlsSettings().getEnabledCipherSuites().isEmpty(), "Enabled Cipher Suites not loaded");
         assertEquals(listenPort.getTlsSettings().getEnabledCipherSuites().size(), 3, "More than 3 cipher suites enabled");
+        assertEquals("Key", listenPort.getTlsSettings().getPrivateKey(), "PrivateKey is not 'Key'");
         assertTrue(listenPort.getTlsSettings().getEnabledCipherSuites().containsAll(asList("TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384")), "Unexpected Cipher Suites enabled");
         assertPropertiesContent(ImmutableMap.of("usesTLS", true), listenPort.getTlsSettings().getProperties());
         assertPropertiesContent(ImmutableMap.of("threadPoolSize", "20"), listenPort.getProperties());

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ListenPortLinkerTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ListenPortLinkerTest.java
@@ -7,6 +7,7 @@
 package com.ca.apim.gateway.cagatewayexport.tasks.explode.linker;
 
 import com.ca.apim.gateway.cagatewayconfig.beans.*;
+import com.ca.apim.gateway.cagatewayconfig.beans.ListenPort.ListenPortTlsSettings;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableSet;
 
@@ -15,7 +16,7 @@ import static org.junit.jupiter.api.Assertions.*;
 class ListenPortLinkerTest {
 
     @Test
-    void linkNoService() {
+    void linkNoServiceNoPrivateKey() {
         ListenPortLinker linker = new ListenPortLinker();
         ListenPort port = new ListenPort();
         port.setName("Port");
@@ -59,6 +60,38 @@ class ListenPortLinkerTest {
         ListenPort port = new ListenPort();
         port.setName("Port");
         port.setTargetServiceReference("Service");
+
+        Bundle bundle = new Bundle();
+        assertThrows(LinkerException.class, () -> linker.link(port, bundle, bundle));
+    }
+
+    @Test
+    void linkWithPrivateKey() {
+        ListenPortLinker linker = new ListenPortLinker();
+        ListenPort port = new ListenPort();
+        port.setName("Port");
+        port.setTlsSettings(new ListenPortTlsSettings());
+        port.getTlsSettings().setPrivateKey("Key");
+        PrivateKey key = new PrivateKey();
+        key.setId("Key");
+        key.setName("Key");
+
+        Bundle bundle = new Bundle();
+        bundle.getPrivateKeys().put(key.getId(), key);
+
+        linker.link(port, bundle, bundle);
+
+        assertNotNull(port.getTlsSettings().getPrivateKey());
+        assertEquals("Key", port.getTlsSettings().getPrivateKey());
+    }
+
+    @Test
+    void linkWithPrivateKeyMissing() {
+        ListenPortLinker linker = new ListenPortLinker();
+        ListenPort port = new ListenPort();
+        port.setName("Port");
+        port.setTlsSettings(new ListenPortTlsSettings());
+        port.getTlsSettings().setPrivateKey("Service");
 
         Bundle bundle = new Bundle();
         assertThrows(LinkerException.class, () -> linker.link(port, bundle, bundle));


### PR DESCRIPTION
Fixes #166 

## Proposed Changes
* Adding `privateKey` to listen-ports configuration file, which has to point to an existing private key available in the bundle.
