### PR TITLE
Skipping export task if folderPath is not specified

### DIFF
--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/config/GatewayExportPluginConfig.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/config/GatewayExportPluginConfig.java
@@ -11,6 +11,7 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Optional;
 
 import java.util.Map;
 
@@ -51,6 +52,7 @@ public class GatewayExportPluginConfig {
      * @return the folder to export from the gateway
      */
     @Input
+    @Optional
     public Property<String> getFolderPath() {
         return folderPath;
     }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/ExplodeBundle.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/ExplodeBundle.java
@@ -23,8 +23,13 @@ import org.w3c.dom.Document;
 import javax.inject.Inject;
 import java.io.File;
 import java.util.Collection;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class ExplodeBundle {
+
+    private static final Logger LOGGER = Logger.getLogger(ExplodeBundle.class.getName());
+
     private final DocumentTools documentTools;
     private final EntityWriterRegistry entityWriterRegistry;
     private final EntityLinkerRegistry entityLinkerRegistry;
@@ -47,6 +52,11 @@ public class ExplodeBundle {
     }
 
     void explodeBundle(String folderPath, FilterConfiguration filterConfiguration, File bundleFile, File explodeDirectory) throws DocumentParseException {
+        if (folderPath == null) {
+            LOGGER.log(Level.FINE, "Skipping exploding bundle due to unspecified folder");
+            return;
+        }
+
         final Document bundleDocument = documentTools.parse(bundleFile);
         documentTools.cleanup(bundleDocument);
 

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/ExplodeBundleTask.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/ExplodeBundleTask.java
@@ -45,6 +45,7 @@ public class ExplodeBundleTask extends DefaultTask {
      * @return The path of the folder to explode.
      */
     @Input
+    @Optional
     public Property<String> getFolderPath() {
         return folderPath;
     }
@@ -74,7 +75,7 @@ public class ExplodeBundleTask extends DefaultTask {
     public void perform() throws DocumentParseException {
         ExplodeBundle explodeBundle = ExportPluginModule.getInjector().getInstance(ExplodeBundle.class);
         checkExportEntities();
-        explodeBundle.explodeBundle(folderPath.getOrElse("/"), toFilterConfiguration(exportEntities.getOrElse(Collections.emptyMap())), inputBundleFile.getAsFile().get(), exportDir.getAsFile().get());
+        explodeBundle.explodeBundle(folderPath.getOrNull(), toFilterConfiguration(exportEntities.getOrElse(Collections.emptyMap())), inputBundleFile.getAsFile().get(), exportDir.getAsFile().get());
     }
 
     /**


### PR DESCRIPTION
Temporary fix for #174 

## Proposed Changes
* Making folderpath Optional Instead of exporting everything if unspecified
* skipping task if unspecified
