### PR TITLE
Loading environment from filesystem mounted files

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/EntityTypeRegistry.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/EntityTypeRegistry.java
@@ -44,6 +44,13 @@ public class EntityTypeRegistry {
         return ofNullable(entityTypeMap.get(entityType)).orElse(NO_INFO).getEntityClass();
     }
 
+    public GatewayEntityInfo getEntityInfoFromEnvironmentType(String environmentType) {
+        return entityTypeMap.values().stream()
+                .filter(gatewayEntityInfo -> environmentType.equals(gatewayEntityInfo.getEnvironmentType()))
+                .findFirst()
+                .orElse(NO_INFO);
+    }
+
     public Map<String, GatewayEntityInfo> getEntityTypeMap() {
         return entityTypeMap;
     }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/EntityTypeRegistry.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/EntityTypeRegistry.java
@@ -20,7 +20,10 @@ import static java.util.Collections.unmodifiableMap;
 import static java.util.Optional.ofNullable;
 
 /**
+ * Registry to store gateway entities metadata read from each entity class.
  *
+ * - key is the entity type from Named annotation
+ * - value is an object GatewayEntityInfo which holds entity type, class, file name for loading, file type (json/yaml or properties) and its environment key for provision as env property.
  */
 @Singleton
 public class EntityTypeRegistry {
@@ -40,15 +43,14 @@ public class EntityTypeRegistry {
         this.entityTypeMap = unmodifiableMap(entityTypes);
     }
 
+    /**
+     * Get the entity class which has the specified type, or the placeholder NO_INFO if not found.
+     *
+     * @param entityType the entity type
+     * @return the entity class
+     */
     public Class<? extends GatewayEntity> getEntityClass(String entityType) {
         return ofNullable(entityTypeMap.get(entityType)).orElse(NO_INFO).getEntityClass();
-    }
-
-    public GatewayEntityInfo getEntityInfoFromEnvironmentType(String environmentType) {
-        return entityTypeMap.values().stream()
-                .filter(gatewayEntityInfo -> environmentType.equals(gatewayEntityInfo.getEnvironmentType()))
-                .findFirst()
-                .orElse(NO_INFO);
     }
 
     public Map<String, GatewayEntityInfo> getEntityTypeMap() {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
@@ -36,6 +36,9 @@ import static java.lang.Boolean.FALSE;
 import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 
+/**
+ * Builder for encass - refer to {@link EntityBuilder} javadoc for more information.
+ */
 @Singleton
 public class EncassEntityBuilder implements EntityBuilder {
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
@@ -52,6 +52,7 @@ public class EncassEntityBuilder implements EntityBuilder {
     }
 
     public List<Entity> build(Bundle bundle, BundleType bundleType, Document document) {
+        // no encass has to be added to environment bundle
         if (bundleType == ENVIRONMENT) {
             return emptyList();
         }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleType.ENVIRONMENT;
 import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilderHelper.getEntityWithNameMapping;
 import static com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes.ENCAPSULATED_ASSERTION_TYPE;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.buildAndAppendPropertiesElement;
@@ -32,6 +33,7 @@ import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConsta
 import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.PALETTE_FOLDER;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.*;
 import static java.lang.Boolean.FALSE;
+import static java.util.Collections.emptyList;
 import static org.apache.commons.lang3.ObjectUtils.firstNonNull;
 
 @Singleton
@@ -47,6 +49,10 @@ public class EncassEntityBuilder implements EntityBuilder {
     }
 
     public List<Entity> build(Bundle bundle, BundleType bundleType, Document document) {
+        if (bundleType == ENVIRONMENT) {
+            return emptyList();
+        }
+
         return bundle.getEncasses().entrySet().stream().map(encassEntry ->
                 buildEncassEntity(bundle, encassEntry.getKey(), encassEntry.getValue(), document)
         ).collect(Collectors.toList());

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EntityBuilder.java
@@ -12,12 +12,24 @@ import org.w3c.dom.Document;
 
 import java.util.List;
 
+/**
+ * An implementation of entity builder is responsible for collecting the entity information stored in yaml/json/properties files or environment properties
+ * and convert this data to a Gateway restman bundle format.
+ *
+ * ex: (input) some-entity-file.json --> SomeEntityBuilder --> Bundle XML element (output)
+ */
 public interface EntityBuilder extends Comparable<EntityBuilder> {
 
     List<Entity> build(Bundle bundle, BundleType bundleType, Document document);
 
+    /**
+     * Types of bundles.
+     */
     enum BundleType {
-        ENVIRONMENT, DEPLOYMENT
+        /** this is the bundle created with the entities that require changes related on where the GW is deployed */
+        ENVIRONMENT,
+        /** this is the bundle that contains gateway behaviour like policies/services/encasses and its dependencies to environment variables */
+        DEPLOYMENT
     }
 
     /**

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EntityBuilder.java
@@ -16,7 +16,7 @@ import java.util.List;
  * An implementation of entity builder is responsible for collecting the entity information stored in yaml/json/properties files or environment properties
  * and convert this data to a Gateway restman bundle format.
  *
- * ex: (input) some-entity-file.json --> SomeEntityBuilder --> Bundle XML element (output)
+ * ex: (input) some-entity-file.json -- SomeEntityBuilder -- Bundle XML element (output)
  */
 public interface EntityBuilder extends Comparable<EntityBuilder> {
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/FolderEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/FolderEntityBuilder.java
@@ -19,6 +19,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleType.ENVIRONMENT;
 import static com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes.FOLDER_TYPE;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingActions.NEW_OR_EXISTING;
@@ -56,7 +57,7 @@ public class FolderEntityBuilder implements EntityBuilder {
     }
 
     public List<Entity> build(Bundle bundle, BundleType bundleType, Document document) {
-        if (bundle.getFolders().isEmpty()) {
+        if (bundle.getFolders().isEmpty() || bundleType == ENVIRONMENT) {
             return Collections.emptyList();
         }
         Map<Folder, Collection<Folder>> folderChildrenMap = new HashMap<>();

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/FolderEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/FolderEntityBuilder.java
@@ -57,6 +57,7 @@ public class FolderEntityBuilder implements EntityBuilder {
     }
 
     public List<Entity> build(Bundle bundle, BundleType bundleType, Document document) {
+        // no folder has to be added to environment bundle
         if (bundle.getFolders().isEmpty() || bundleType == ENVIRONMENT) {
             return Collections.emptyList();
         }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyBackedServiceEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyBackedServiceEntityBuilder.java
@@ -19,10 +19,12 @@ import javax.inject.Singleton;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleType.ENVIRONMENT;
 import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilderHelper.getEntityWithNameMapping;
 import static com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes.POLICY_BACKED_SERVICE_TYPE;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.*;
+import static java.util.Collections.emptyList;
 
 @Singleton
 public class PolicyBackedServiceEntityBuilder implements EntityBuilder {
@@ -36,6 +38,10 @@ public class PolicyBackedServiceEntityBuilder implements EntityBuilder {
     }
 
     public List<Entity> build(Bundle bundle, BundleType bundleType, Document document) {
+        if (bundleType == ENVIRONMENT) {
+            return emptyList();
+        }
+
         return bundle.getPolicyBackedServices().entrySet().stream().map(pbsEntry ->
                 buildPBSEntity(bundle, pbsEntry.getKey(), pbsEntry.getValue(), document)
         ).collect(Collectors.toList());

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyBackedServiceEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyBackedServiceEntityBuilder.java
@@ -38,6 +38,7 @@ public class PolicyBackedServiceEntityBuilder implements EntityBuilder {
     }
 
     public List<Entity> build(Bundle bundle, BundleType bundleType, Document document) {
+        // no pbs has to be added to environment bundle
         if (bundleType == ENVIRONMENT) {
             return emptyList();
         }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
@@ -30,12 +30,14 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleType.ENVIRONMENT;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.buildAndAppendPropertiesElement;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.insertPrefixToEnvironmentVariable;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.*;
+import static java.util.Collections.emptyList;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.lang3.StringUtils.isNotEmpty;
 
@@ -61,6 +63,10 @@ public class PolicyEntityBuilder implements EntityBuilder {
     }
 
     public List<Entity> build(Bundle bundle, BundleType bundleType, Document document) {
+        if (bundleType == ENVIRONMENT) {
+            return emptyList();
+        }
+
         bundle.getPolicies().values().forEach(policy -> preparePolicy(policy, bundle));
 
         List<Policy> orderedPolicies = new LinkedList<>();

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
@@ -63,6 +63,7 @@ public class PolicyEntityBuilder implements EntityBuilder {
     }
 
     public List<Entity> build(Bundle bundle, BundleType bundleType, Document document) {
+        // no policy has to be added to environment bundle
         if (bundleType == ENVIRONMENT) {
             return emptyList();
         }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ScheduledTaskEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ScheduledTaskEntityBuilder.java
@@ -20,12 +20,14 @@ import javax.inject.Singleton;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleType.ENVIRONMENT;
 import static com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes.SCHEDULED_TASK_TYPE;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.buildAndAppendPropertiesElement;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.createElementWithAttribute;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.createElementWithAttributesAndChildren;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.createElementWithTextContent;
+import static java.util.Collections.emptyList;
 
 @Singleton
 public class ScheduledTaskEntityBuilder implements EntityBuilder {
@@ -39,6 +41,10 @@ public class ScheduledTaskEntityBuilder implements EntityBuilder {
 
     @Override
     public List<Entity> build(Bundle bundle, BundleType bundleType, Document document) {
+        if (bundleType == ENVIRONMENT) {
+            return emptyList();
+        }
+
         return bundle.getScheduledTasks().entrySet().stream().map(scheduledTaskEntry ->
                 buildScheduledTaskEntity(bundle, scheduledTaskEntry.getKey(), scheduledTaskEntry.getValue(), document)
         ).collect(Collectors.toList());

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ScheduledTaskEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ScheduledTaskEntityBuilder.java
@@ -41,6 +41,7 @@ public class ScheduledTaskEntityBuilder implements EntityBuilder {
 
     @Override
     public List<Entity> build(Bundle bundle, BundleType bundleType, Document document) {
+        // no sched task has to be added to environment bundle
         if (bundleType == ENVIRONMENT) {
             return emptyList();
         }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ServiceEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ServiceEntityBuilder.java
@@ -48,6 +48,7 @@ public class ServiceEntityBuilder implements EntityBuilder {
     }
 
     public List<Entity> build(Bundle bundle, BundleType bundleType, Document document) {
+        // no service has to be added to environment bundle
         if (bundleType == ENVIRONMENT) {
             return emptyList();
         }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ServiceEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ServiceEntityBuilder.java
@@ -25,12 +25,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleType.ENVIRONMENT;
 import static com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes.SERVICE_TYPE;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.buildAndAppendPropertiesElement;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.insertPrefixToEnvironmentVariable;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.*;
+import static java.util.Collections.emptyList;
 
 @Singleton
 public class ServiceEntityBuilder implements EntityBuilder {
@@ -46,6 +48,10 @@ public class ServiceEntityBuilder implements EntityBuilder {
     }
 
     public List<Entity> build(Bundle bundle, BundleType bundleType, Document document) {
+        if (bundleType == ENVIRONMENT) {
+            return emptyList();
+        }
+
         return bundle.getServices().entrySet().stream().map(serviceEntry ->
                 buildServiceEntity(bundle, serviceEntry.getKey(), serviceEntry.getValue(), document)
         ).collect(Collectors.toList());

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleBuilder.java
@@ -9,19 +9,27 @@ package com.ca.apim.gateway.cagatewayconfig.environment;
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.config.loader.EntityLoader;
 import com.ca.apim.gateway.cagatewayconfig.config.loader.EntityLoaderRegistry;
+import com.ca.apim.gateway.cagatewayconfig.util.environment.EnvironmentConfigurationUtils;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.io.File;
 import java.util.Map;
 
 @Singleton
 public class EnvironmentBundleBuilder {
 
+    private static final String ENVIRONMENT_FILES_CONFIG_PATH = "/opt/SecureSpan/Gateway/node/default/etc/bootstrap/env";
+    private static final String ENV_PREFIX = "ENV.";
+    private static final String FILE_PREFIX = "FILE.";
+
     private final EntityLoaderRegistry entityLoaderRegistry;
+    private final EnvironmentConfigurationUtils environmentConfigurationUtils;
 
     @Inject
-    EnvironmentBundleBuilder(EntityLoaderRegistry entityLoaderRegistry) {
+    EnvironmentBundleBuilder(EntityLoaderRegistry entityLoaderRegistry, EnvironmentConfigurationUtils environmentConfigurationUtils) {
         this.entityLoaderRegistry = entityLoaderRegistry;
+        this.environmentConfigurationUtils = environmentConfigurationUtils;
     }
 
     void build(Bundle bundle, Map<String, String> environmentProperties) {
@@ -29,17 +37,35 @@ public class EnvironmentBundleBuilder {
     }
 
     private void addEnvToBundle(Bundle bundle, String key, String value) {
-        if (key.startsWith("ENV.")) {
-            String environmentKey = key.substring(4);
-            int typeEndIndex = environmentKey.indexOf('.');
-            if(typeEndIndex != -1) {
-                String type = environmentKey.substring(0, typeEndIndex);
-                EntityLoader loader = entityLoaderRegistry.getLoader(type);
-                if(loader != null) {
-                    String name = environmentKey.substring(type.length() + 1);
-                    loader.load(bundle, name, value);
-                }
-            }
+        if (!key.startsWith(ENV_PREFIX)) {
+            return;
         }
+
+        String environmentKey = key.substring(4);
+        // check if var is starting with file prefix - then remove if true
+        boolean isFile = environmentKey.startsWith(FILE_PREFIX);
+        if (isFile) {
+            environmentKey = environmentKey.substring(5);
+        }
+
+        int typeEndIndex = environmentKey.indexOf('.');
+        if (typeEndIndex == -1) {
+            return;
+        }
+
+        String type = environmentKey.substring(0, typeEndIndex);
+        EntityLoader loader = entityLoaderRegistry.getLoader(type);
+        if (loader == null) {
+            return;
+        }
+
+        String name = environmentKey.substring(type.length() + 1);
+        if (isFile) {
+            // if we have a file, replace the value contents with the content load from the file in JSON specification.
+            value = environmentConfigurationUtils.loadConfigFromFile(new File(ENVIRONMENT_FILES_CONFIG_PATH, value), type, name);
+        }
+
+        // then load it
+        loader.load(bundle, name, value);
     }
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleBuilder.java
@@ -20,6 +20,10 @@ import java.util.Map;
 import static com.ca.apim.gateway.cagatewayconfig.environment.EnvironmentBundleCreationMode.APPLICATION;
 import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.PREFIX_ENV;
 
+/**
+ * Collect values from provided environment variables/files and generates a restman bundle with those values.
+ * Each value is an entity that when loaded outputs to a bundle xml element.
+ */
 @Singleton
 @SuppressWarnings("squid:S2083") // This warn relates to path injection attacks - however, paths here are never changed by end users and all self contained into docker containers.
 public class EnvironmentBundleBuilder {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleBuilder.java
@@ -14,7 +14,6 @@ import com.ca.apim.gateway.cagatewayconfig.util.environment.EnvironmentConfigura
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.File;
-import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Map;
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleBuilder.java
@@ -14,6 +14,7 @@ import com.ca.apim.gateway.cagatewayconfig.util.environment.EnvironmentConfigura
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Map;
 
@@ -21,6 +22,7 @@ import static com.ca.apim.gateway.cagatewayconfig.environment.EnvironmentBundleC
 import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.PREFIX_ENV;
 
 @Singleton
+@SuppressWarnings("squid:S2083") // This warn relates to path injection attacks - however, paths here are never changed by end users and all self contained into docker containers.
 public class EnvironmentBundleBuilder {
 
     private static final String FILE_PREFIX = "FILE.";

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleCreator.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleCreator.java
@@ -48,10 +48,11 @@ public class EnvironmentBundleCreator {
     public Bundle createEnvironmentBundle(Map<String, String> environmentProperties,
                                           String bundleFolderPath,
                                           String templatizedBundleFolderPath,
+                                          String environmentConfigurationFolderPath,
                                           EnvironmentBundleCreationMode mode,
                                           String bundleFileName) {
         Bundle environmentBundle = new Bundle();
-        environmentBundleBuilder.build(environmentBundle, environmentProperties);
+        environmentBundleBuilder.build(environmentBundle, environmentProperties, environmentConfigurationFolderPath, mode);
 
         processDeploymentBundles(
                 environmentBundle,

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/FullBundleCreator.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/FullBundleCreator.java
@@ -36,6 +36,7 @@ import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSing
 import static java.nio.charset.Charset.defaultCharset;
 import static java.util.stream.Collectors.toList;
 import static org.apache.commons.io.FileUtils.writeStringToFile;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 @Singleton
 public class FullBundleCreator {
@@ -75,7 +76,7 @@ public class FullBundleCreator {
 
         // generate the environment one
         Bundle environmentBundle = new Bundle();
-        environmentBundleBuilder.build(environmentBundle, environmentProperties);
+        environmentBundleBuilder.build(environmentBundle, environmentProperties, EMPTY, PLUGIN);
 
         // validate and detemplatize
         processDeploymentBundles(environmentBundle, templatizedBundles, PLUGIN);

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/FullBundleCreator.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/FullBundleCreator.java
@@ -38,6 +38,10 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.commons.io.FileUtils.writeStringToFile;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 
+/**
+ * This combines the environment bundle generation with the deployment bundle generation and outputs one single full bundle
+ * with everything on it. This is used to output the whole solution in one bundle and allow to be installed into non ephemeral gateways.
+ */
 @Singleton
 public class FullBundleCreator {
 

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/FolderEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/FolderEntityBuilderTest.java
@@ -20,6 +20,7 @@ import org.w3c.dom.Element;
 import java.util.List;
 import java.util.Map;
 
+import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleType.DEPLOYMENT;
 import static com.ca.apim.gateway.cagatewayconfig.util.TestUtils.createFolder;
 import static com.ca.apim.gateway.cagatewayconfig.util.TestUtils.createRoot;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
@@ -41,7 +42,7 @@ class FolderEntityBuilderTest {
     @Test
     void buildFromEmptyBundle_noFolders() {
         FolderEntityBuilder builder = new FolderEntityBuilder(ID_GENERATOR);
-        final List<Entity> entities = builder.build(new Bundle(), BundleType.DEPLOYMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
+        final List<Entity> entities = builder.build(new Bundle(), DEPLOYMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
 
         assertTrue(entities.isEmpty());
     }
@@ -52,27 +53,32 @@ class FolderEntityBuilderTest {
         Bundle bundle = new Bundle();
         bundle.putAllFolders(createTestFolders(null));
 
-        assertThrows(EntityBuilderException.class, () -> builder.build(bundle, BundleType.DEPLOYMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument()));
+        assertThrows(EntityBuilderException.class, () -> builder.build(bundle, DEPLOYMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument()));
     }
 
     @Test
     void buildEnvironment() {
-        build(BundleType.ENVIRONMENT);
-    }
-
-    @Test
-    void buildDeployment() {
-        build(BundleType.DEPLOYMENT);
-    }
-
-    private static void build(BundleType bundleType) {
         FolderEntityBuilder builder = new FolderEntityBuilder(ID_GENERATOR);
         Bundle bundle = new Bundle();
         Folder root = createRoot();
         bundle.getFolders().put(EMPTY, root);
         bundle.putAllFolders(createTestFolders(root));
 
-        final List<Entity> entities = builder.build(bundle, bundleType, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
+        final List<Entity> entities = builder.build(bundle, BundleType.ENVIRONMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
+
+        assertNotNull(entities);
+        assertTrue(entities.isEmpty());
+    }
+
+    @Test
+    void buildDeployment() {
+        FolderEntityBuilder builder = new FolderEntityBuilder(ID_GENERATOR);
+        Bundle bundle = new Bundle();
+        Folder root = createRoot();
+        bundle.getFolders().put(EMPTY, root);
+        bundle.putAllFolders(createTestFolders(root));
+
+        final List<Entity> entities = builder.build(bundle, DEPLOYMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
 
         assertNotNull(entities);
         assertFalse(entities.isEmpty());

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyBackedServiceEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyBackedServiceEntityBuilderTest.java
@@ -47,21 +47,26 @@ class PolicyBackedServiceEntityBuilderTest {
     @Test
     void buildWithNoPolicy() {
         final Bundle bundle = new Bundle();
-        assertThrows(EntityBuilderException.class, () -> buildBundleWithPBS(bundle, BundleType.DEPLOYMENT));
+        assertThrows(EntityBuilderException.class, () -> buildBundleWithPBS(bundle));
     }
 
     @Test
     void buildDeploymentWithPBS() {
         final Bundle bundle = new Bundle();
         putPolicy(bundle);
-        buildBundleWithPBS(bundle, BundleType.DEPLOYMENT);
+        buildBundleWithPBS(bundle);
     }
 
     @Test
     void buildEnvironmentWithPBS() {
         final Bundle bundle = new Bundle();
         putPolicy(bundle);
-        buildBundleWithPBS(bundle, BundleType.ENVIRONMENT);
+        PolicyBackedServiceEntityBuilder builder = new PolicyBackedServiceEntityBuilder(ID_GENERATOR);
+        bundle.putAllPolicyBackedServices(ImmutableMap.of(TEST_PBS, buildTestPBS()));
+
+        final List<Entity> entities = builder.build(bundle, BundleType.ENVIRONMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
+
+        assertTrue(entities.isEmpty());
     }
 
     private static void putPolicy(Bundle bundle) {
@@ -71,11 +76,11 @@ class PolicyBackedServiceEntityBuilderTest {
         bundle.getPolicies().put(TEST_POLICY, policy);
     }
 
-    private static void buildBundleWithPBS(Bundle bundle, BundleType deployment) {
+    private static void buildBundleWithPBS(Bundle bundle) {
         PolicyBackedServiceEntityBuilder builder = new PolicyBackedServiceEntityBuilder(ID_GENERATOR);
         bundle.putAllPolicyBackedServices(ImmutableMap.of(TEST_PBS, buildTestPBS()));
 
-        final List<Entity> entities = builder.build(bundle, deployment, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
+        final List<Entity> entities = builder.build(bundle, BundleType.DEPLOYMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
 
         assertFalse(entities.isEmpty());
         assertEquals(1, entities.size());

--- a/environment-creator-application/src/main/java/com/ca/apim/gateway/cagatewayconfig/EnvironmentCreatorApplication.java
+++ b/environment-creator-application/src/main/java/com/ca/apim/gateway/cagatewayconfig/EnvironmentCreatorApplication.java
@@ -18,6 +18,7 @@ import static com.ca.apim.gateway.cagatewayconfig.KeystoreCreator.createKeyStore
 import static com.ca.apim.gateway.cagatewayconfig.environment.EnvironmentBundleCreationMode.APPLICATION;
 import static java.lang.System.getenv;
 
+@SuppressWarnings("squid:S2083") // This warn relates to path injection attacks - however, paths here are never changed by end users and all self contained into docker containers.
 public class EnvironmentCreatorApplication {
 
     @SuppressWarnings("squid:S1075") // this path is always fixed does not need to be customized.
@@ -86,6 +87,5 @@ public class EnvironmentCreatorApplication {
         // Create the KeyStore
         createKeyStoreIfNecessary(keystoreFolderPath, privateKeyFolderPath, environmentBundle.getPrivateKeys().values(), FileUtils.INSTANCE, SYSTEM_PROPERTIES_PATH);
     }
-
 
 }

--- a/environment-creator-application/src/main/java/com/ca/apim/gateway/cagatewayconfig/EnvironmentCreatorApplication.java
+++ b/environment-creator-application/src/main/java/com/ca/apim/gateway/cagatewayconfig/EnvironmentCreatorApplication.java
@@ -18,6 +18,13 @@ import static com.ca.apim.gateway.cagatewayconfig.KeystoreCreator.createKeyStore
 import static com.ca.apim.gateway.cagatewayconfig.environment.EnvironmentBundleCreationMode.APPLICATION;
 import static java.lang.System.getenv;
 
+/**
+ * This is the entrypoint for the environment creator application.
+ * This runs on docker container startup and is responsible to collect provided environment properties and generate a restman bundle with them.
+ * This bundle will be added to gateway bootstrap folder in order to be loaded with the gateway startup, and will be placed to be loaded first.
+ *
+ * This application also is responsible to read private keys folder if provided, and bootstrap a file based keystore from the keys presented.
+ */
 @SuppressWarnings("squid:S2083") // This warn relates to path injection attacks - however, paths here are never changed by end users and all self contained into docker containers.
 public class EnvironmentCreatorApplication {
 

--- a/environment-creator-application/src/main/java/com/ca/apim/gateway/cagatewayconfig/EnvironmentCreatorApplication.java
+++ b/environment-creator-application/src/main/java/com/ca/apim/gateway/cagatewayconfig/EnvironmentCreatorApplication.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import static com.ca.apim.gateway.cagatewayconfig.KeystoreCreator.createKeyStoreIfNecessary;
 import static com.ca.apim.gateway.cagatewayconfig.environment.EnvironmentBundleCreationMode.APPLICATION;
+import static java.lang.System.getenv;
 
 public class EnvironmentCreatorApplication {
 
@@ -27,6 +28,7 @@ public class EnvironmentCreatorApplication {
     private final String bootstrapBundleFolderPath;
     private final String keystoreFolderPath;
     private final String privateKeyFolderPath;
+    private final String environmentConfigurationFolderPath;
 
     /**
      * This application will build an environment bundle and detemplatize deployment bundles with environment configurations.
@@ -41,21 +43,31 @@ public class EnvironmentCreatorApplication {
         String templatizedBundleFolderPath = args.length > 0 ? args[0] : "/opt/docker/rc.d/bundle/templatized";
         String bootstrapBundleFolderPath = args.length > 1 ? args[1] : "/opt/SecureSpan/Gateway/node/default/etc/bootstrap/bundle/";
         String keystoreFolderPath = args.length > 2 ? args[2] : "/opt/docker/rc.d/keystore";
-        String privateKeyFolderPath = args.length > 3 ? args[3] : "/opt/SecureSpan/Gateway/node/default/etc/bootstrap/env/privateKeys";
+        String privateKeyFolderPath = args.length > 3 ? args[3] : "/opt/SecureSpan/Gateway/node/default/etc/bootstrap/env/config/privateKeys";
+        String environmentConfigurationFolderPath = args.length > 4 ? args[4] : "/opt/SecureSpan/Gateway/node/default/etc/bootstrap/env";
 
-        new EnvironmentCreatorApplication(System.getenv(), templatizedBundleFolderPath, bootstrapBundleFolderPath, keystoreFolderPath, privateKeyFolderPath).run();
+        new EnvironmentCreatorApplication(
+                getenv(),
+                templatizedBundleFolderPath,
+                bootstrapBundleFolderPath,
+                keystoreFolderPath,
+                privateKeyFolderPath,
+                environmentConfigurationFolderPath
+        ).run();
     }
 
     EnvironmentCreatorApplication(Map<String, String> environmentProperties,
                                   String templatizedBundleFolderPath,
                                   String bootstrapBundleFolderPath,
                                   String keystoreFolderPath,
-                                  String privateKeyFolderPath) {
+                                  String privateKeyFolderPath,
+                                  String environmentConfigurationFolderPath) {
         this.environmentProperties = environmentProperties;
         this.templatizedBundleFolderPath = templatizedBundleFolderPath;
         this.bootstrapBundleFolderPath = bootstrapBundleFolderPath;
         this.keystoreFolderPath = keystoreFolderPath;
         this.privateKeyFolderPath = privateKeyFolderPath;
+        this.environmentConfigurationFolderPath = environmentConfigurationFolderPath;
     }
 
     @VisibleForTesting
@@ -66,6 +78,7 @@ public class EnvironmentCreatorApplication {
                 environmentProperties,
                 bootstrapBundleFolderPath,
                 templatizedBundleFolderPath,
+                environmentConfigurationFolderPath,
                 APPLICATION,
                 "_0_env.req.bundle"
         );

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildEnvironmentBundleTask.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/BuildEnvironmentBundleTask.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import static com.ca.apim.gateway.cagatewayconfig.environment.EnvironmentBundleCreationMode.PLUGIN;
 import static com.ca.apim.gateway.cagatewayconfig.util.injection.ConfigBuilderModule.getInstance;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
 
 /**
  * The BuildEnvironmentBundle task will grab provided environment properties and build a bundle.
@@ -57,6 +58,7 @@ public class BuildEnvironmentBundleTask extends DefaultTask {
                 environmentValues,
                 into.getAsFile().get().getPath(),
                 into.getAsFile().get().getPath(),
+                EMPTY,
                 PLUGIN,
                 bundleFileName
         );

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/PolicyXMLSimplifier.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/PolicyXMLSimplifier.java
@@ -28,6 +28,8 @@ import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.inse
 import static com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider.INTERNAL_IDP_ID;
 import static com.ca.apim.gateway.cagatewayconfig.beans.IdentityProvider.INTERNAL_IDP_NAME;
 import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.*;
+import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.PREFIX_ENV;
+import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.PREFIX_GATEWAY;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.createElementWithAttribute;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleElement;
 
@@ -79,8 +81,8 @@ public class PolicyXMLSimplifier {
 
         Element variableToSetElement = getSingleElement(element, VARIABLE_TO_SET);
         String variableName = variableToSetElement.getAttribute(STRING_VALUE);
-        if (variableName.startsWith("ENV.")) {
-            if (variableName.startsWith("ENV.gateway.")) {
+        if (variableName.startsWith(PREFIX_ENV)) {
+            if (variableName.startsWith(PREFIX_ENV + PREFIX_GATEWAY)) {
                 throw new LinkerException("Cannot have local environment property start with the prefix `ENV.gateway.`. Property: " + variableName);
             }
             ContextVariableEnvironmentProperty contextVarEnvironmentProperty = new ContextVariableEnvironmentProperty(insertPrefixToEnvironmentVariable(variableName, policyName).substring(4), new String(decodedValue));


### PR DESCRIPTION
Fixes #173

## Proposed Changes
* Use mounted directory or specific files to load environment values. This allow to use local yaml/json files and avoid copy paste to docker-compose or gradle files.
