### PR TITLE
DE408011 Fix exporting when gateway has 2+ folders starting with the same prefix

### DIFF
--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/filter/entityfilters/FolderFilter.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/filter/entityfilters/FolderFilter.java
@@ -29,7 +29,7 @@ public class FolderFilter implements EntityFilter<Folder> {
                 .filter(f -> {
                     String path = bundle.getFolderTree().getFormattedPath(f);
                     // Children folders have a path that starts with the folder path
-                    return ("/" + path).startsWith(folderPath);
+                    return ("/" + path + "/").startsWith(folderPath + "/");
                 }).collect(Collectors.toList());
     }
 

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/filter/entityfilters/FolderFilter.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/filter/entityfilters/FolderFilter.java
@@ -29,6 +29,7 @@ public class FolderFilter implements EntityFilter<Folder> {
                 .filter(f -> {
                     String path = bundle.getFolderTree().getFormattedPath(f);
                     // Children folders have a path that starts with the folder path
+                    // Adding end slashes to ensure path is complete
                     return ("/" + path + "/").startsWith(folderPath + "/");
                 }).collect(Collectors.toList());
     }

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/filter/entityfilters/FolderFilterTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/filter/entityfilters/FolderFilterTest.java
@@ -97,4 +97,22 @@ class FolderFilterTest {
         assertTrue(parentFolders.stream().anyMatch(f -> "folder".equals(f.getName())));
         assertTrue(parentFolders.stream().anyMatch(f -> "path".equals(f.getName())));
     }
+
+    @Test
+    void filterBundleWithMultipleFoldersStartingWithTheSameName() {
+        Bundle bundle = FilterTestUtils.getBundle();
+        Folder folder1 = createFolder("Folder Test", "1", Folder.ROOT_FOLDER);
+        Folder folder2 = createFolder("Folder Test 2", "2", Folder.ROOT_FOLDER);
+        bundle.addEntity(folder1);
+        bundle.addEntity(folder2);
+        bundle.setFolderTree(new FolderTree(bundle.getEntities(Folder.class).values()));
+
+        FolderFilter folderFilter = new FolderFilter();
+
+        Bundle filteredBundle = new Bundle();
+        List<Folder> childFolders = folderFilter.filter("/Folder Test", new FilterConfiguration(), bundle, filteredBundle);
+
+        assertEquals(1, childFolders.size());
+        assertEquals("Folder Test", childFolders.iterator().next().getName());
+    }
 }


### PR DESCRIPTION
Fixes [DE408011](https://rally1.rallydev.com/#/56296273706d/detail/defect/291950254232)

## Proposed Changes
* Adding extra slash on folder filtering to ensure path is completed.
