### PR TITLE
Feature/US581740 unsupported policy name

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/FolderEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/FolderEntityBuilder.java
@@ -9,7 +9,7 @@ package com.ca.apim.gateway.cagatewayconfig.bundle.builder;
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.beans.Folder;
 import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
-import com.ca.apim.gateway.cagatewayconfig.util.string.EncodeDecodeUtils;
+import com.ca.apim.gateway.cagatewayconfig.util.string.CharacterBlacklistUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -43,14 +43,14 @@ public class FolderEntityBuilder implements EntityBuilder {
         if (parentFolderId != null) {
             folder.setAttribute(ATTRIBUTE_FOLDER_ID, parentFolderId);
         }
-        String decodedName = EncodeDecodeUtils.decodePath(name);
-        folder.appendChild(createElementWithTextContent(document, NAME, decodedName));
+        String filteredName = CharacterBlacklistUtil.filterAndReplace(name);
+        folder.appendChild(createElementWithTextContent(document, NAME, filteredName));
         final Entity entity;
         if (parentFolderId == null) {
             //No need to map root folder by name
-            entity = new Entity(FOLDER_TYPE, decodedName, id, folder);
+            entity = new Entity(FOLDER_TYPE, filteredName, id, folder);
         } else {
-            entity = EntityBuilderHelper.getEntityWithNameMapping(FOLDER_TYPE, decodedName, id, folder);
+            entity = EntityBuilderHelper.getEntityWithNameMapping(FOLDER_TYPE, filteredName, id, folder);
         }
         entity.setMappingAction(NEW_OR_EXISTING);
         return entity;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
@@ -10,7 +10,6 @@ import com.ca.apim.gateway.cagatewayconfig.beans.*;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames;
 import com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements;
-import com.ca.apim.gateway.cagatewayconfig.util.string.EncodeDecodeUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
 import com.google.common.annotations.VisibleForTesting;
@@ -294,7 +293,7 @@ public class PolicyEntityBuilder implements EntityBuilder {
                 document,
                 POLICY_DETAIL,
                 ImmutableMap.of(ATTRIBUTE_ID, id, ATTRIBUTE_GUID, policy.getGuid(), ATTRIBUTE_FOLDER_ID, policy.getParentFolder().getId()),
-                createElementWithTextContent(document, NAME, EncodeDecodeUtils.decodePath(policy.getName())),
+                createElementWithTextContent(document, NAME, policy.getName()),
                 createElementWithTextContent(document, POLICY_TYPE, policyTags == null ? PolicyType.INCLUDE.getType() : policyTags.type.getType())
         );
 
@@ -325,7 +324,7 @@ public class PolicyEntityBuilder implements EntityBuilder {
         resourceSetElement.appendChild(resourceElement);
         resourcesElement.appendChild(resourceSetElement);
         policyElement.appendChild(resourcesElement);
-        return EntityBuilderHelper.getEntityWithPathMapping(EntityTypes.POLICY_TYPE, EncodeDecodeUtils.decodePath(policy.getPath()), id, policyElement);
+        return EntityBuilderHelper.getEntityWithPathMapping(EntityTypes.POLICY_TYPE, policy.getPath(), id, policyElement);
     }
 
     private PolicyTags getPolicyTags(Policy policy, Bundle bundle) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ServiceEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ServiceEntityBuilder.java
@@ -11,10 +11,8 @@ import com.ca.apim.gateway.cagatewayconfig.beans.Policy;
 import com.ca.apim.gateway.cagatewayconfig.beans.Service;
 import com.ca.apim.gateway.cagatewayconfig.beans.Wsdl;
 import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
-import com.ca.apim.gateway.cagatewayconfig.util.string.EncodeDecodeUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
 import com.google.common.collect.ImmutableMap;
-import org.apache.commons.io.FilenameUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -64,8 +62,8 @@ public class ServiceEntityBuilder implements EntityBuilder {
     }
 
     private Entity buildServiceEntity(Bundle bundle, String servicePath, Service service, Document document) {
-        String processedName = EncodeDecodeUtils.decodePath(FilenameUtils.getBaseName(servicePath));
-        service.setName(processedName);
+        String baseName = servicePath.substring(servicePath.lastIndexOf("/") + 1);
+        service.setName(baseName);
 
         Policy policy = bundle.getPolicies().get(service.getPolicy());
         final Wsdl wsdlBean = service.getWsdl();
@@ -83,7 +81,7 @@ public class ServiceEntityBuilder implements EntityBuilder {
         service.setId(id);
 
         Element serviceDetailElement = createElementWithAttributes(document, SERVICE_DETAIL, ImmutableMap.of(ATTRIBUTE_ID, id, ATTRIBUTE_FOLDER_ID, service.getParentFolder().getId()));
-        serviceDetailElement.appendChild(createElementWithTextContent(document, NAME, processedName));
+        serviceDetailElement.appendChild(createElementWithTextContent(document, NAME, baseName));
         serviceDetailElement.appendChild(createElementWithTextContent(document, ENABLED, Boolean.TRUE.toString()));
         serviceDetailElement.appendChild(buildServiceMappings(service, document));
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ServiceEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ServiceEntityBuilder.java
@@ -62,7 +62,7 @@ public class ServiceEntityBuilder implements EntityBuilder {
     }
 
     private Entity buildServiceEntity(Bundle bundle, String servicePath, Service service, Document document) {
-        String baseName = servicePath.substring(servicePath.lastIndexOf("/") + 1);
+        String baseName = servicePath.substring(servicePath.lastIndexOf('/') + 1);
         service.setName(baseName);
 
         Policy policy = bundle.getPolicies().get(service.getPolicy());

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/FolderLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/FolderLoader.java
@@ -9,7 +9,7 @@ package com.ca.apim.gateway.cagatewayconfig.bundle.loader;
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.beans.Folder;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
-import com.ca.apim.gateway.cagatewayconfig.util.string.EncodeDecodeUtils;
+import com.ca.apim.gateway.cagatewayconfig.util.string.CharacterBlacklistUtil;
 import org.w3c.dom.Element;
 
 import javax.inject.Singleton;
@@ -46,7 +46,7 @@ public class FolderLoader implements BundleEntityLoader {
             parentFolder = parentFolderList.get(0);
         }
 
-        if (EncodeDecodeUtils.containsInvalidCharacter(name)) {
+        if (CharacterBlacklistUtil.containsInvalidCharacter(name)) {
             throw new BundleLoadException("Folder name contains invalid characters: " + name);
         }
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/PolicyLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/PolicyLoader.java
@@ -18,8 +18,7 @@ import java.util.logging.Logger;
 
 import static com.ca.apim.gateway.cagatewayconfig.beans.PolicyType.GLOBAL;
 import static com.ca.apim.gateway.cagatewayconfig.beans.PolicyType.INTERNAL;
-import static com.ca.apim.gateway.cagatewayconfig.bundle.loader.ServiceAndPolicyLoaderUtil.getFolder;
-import static com.ca.apim.gateway.cagatewayconfig.bundle.loader.ServiceAndPolicyLoaderUtil.getPath;
+import static com.ca.apim.gateway.cagatewayconfig.bundle.loader.ServiceAndPolicyLoaderUtil.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.mapPropertiesElements;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.PROPERTY_TAG;
@@ -75,6 +74,14 @@ public class PolicyLoader implements BundleEntityLoader {
         policy.setPolicyType(type);
         policy.setPolicyDocument(policyElement);
         policy.setPolicyXML(policyString);
+
+        Map<String, Policy> bundlePolicies = bundle.getPolicies();
+
+        if (bundlePolicies.containsKey(policy.getPath())) {
+            String duplicatePathName = handleDuplicatePathName(bundlePolicies, policy);
+            policy.setName(duplicatePathName.substring(duplicatePathName.lastIndexOf('/') + 1));
+            policy.setPath(duplicatePathName);
+        }
 
         bundle.getPolicies().put(policy.getPath(), policy);
         if (type == GLOBAL) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceAndPolicyLoaderUtil.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceAndPolicyLoaderUtil.java
@@ -13,7 +13,7 @@ public class ServiceAndPolicyLoaderUtil {
     /**
      * Get path with file name
      *
-     * @param parentFolder
+     * @param parentFolder parent folder for file name to appended on to for path
      * @param fileName name used to create a path with parent folder
      * @return a path ending with name
      */

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceAndPolicyLoaderUtil.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceAndPolicyLoaderUtil.java
@@ -10,10 +10,24 @@ import java.util.stream.Collectors;
 
 public class ServiceAndPolicyLoaderUtil {
 
-    public static String getPath(Folder parentFolder, String name) {
-        return PathUtils.unixPath(Paths.get(parentFolder.getPath()).resolve(name));
+    /**
+     * Get path with file name
+     *
+     * @param parentFolder
+     * @param fileName name used to create a path with parent folder
+     * @return a path ending with name
+     */
+    public static String getPath(Folder parentFolder, String fileName) {
+        return PathUtils.unixPath(Paths.get(parentFolder.getPath()).resolve(fileName));
     }
 
+    /**
+     * Extract folder object from bundle
+     *
+     * @param bundle bundle contaning the folder
+     * @param folderId id of folder to be extracted from bundle
+     * @return folder object from bundle
+     */
     public static Folder getFolder(Bundle bundle, String folderId) {
         List<Folder> folderList = bundle.getFolders().values().stream().filter(f -> folderId.equals(f.getId())).collect(Collectors.toList());
         if (folderList.isEmpty()) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceAndPolicyLoaderUtil.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceAndPolicyLoaderUtil.java
@@ -12,6 +12,8 @@ import java.util.stream.Collectors;
 
 public class ServiceAndPolicyLoaderUtil {
 
+    public static final String HANDLE_DUPLICATE_NAMES = "com.ca.apim.export.handleDuplicateNames";
+
     /**
      * Get path with file name
      *
@@ -53,8 +55,9 @@ public class ServiceAndPolicyLoaderUtil {
         int duplicateCounter = 2;
         String basePath = entity.getPath();
         String clonePath = basePath;
+        String sysProp = System.getProperty(HANDLE_DUPLICATE_NAMES);
 
-        if (System.getProperty("exportDuplicate").equals("true")) {
+        if (sysProp != null && sysProp.equals("true")) {
             while (bundleEntity.containsKey(clonePath)) {
                 Folderable service = bundleEntity.get(clonePath);
                 if (!service.getId().equals(entity.getId())

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceAndPolicyLoaderUtil.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceAndPolicyLoaderUtil.java
@@ -1,0 +1,26 @@
+package com.ca.apim.gateway.cagatewayconfig.bundle.loader;
+
+import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
+import com.ca.apim.gateway.cagatewayconfig.beans.Folder;
+import com.ca.apim.gateway.cagatewayconfig.util.paths.PathUtils;
+
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class ServiceAndPolicyLoaderUtil {
+
+    public static String getPath(Folder parentFolder, String name) {
+        return PathUtils.unixPath(Paths.get(parentFolder.getPath()).resolve(name));
+    }
+
+    public static Folder getFolder(Bundle bundle, String folderId) {
+        List<Folder> folderList = bundle.getFolders().values().stream().filter(f -> folderId.equals(f.getId())).collect(Collectors.toList());
+        if (folderList.isEmpty()) {
+            throw new BundleLoadException("Invalid dependency bundle. Could not find folder with id: " + folderId);
+        } else if (folderList.size() > 1) {
+            throw new BundleLoadException("Invalid dependency bundle. Found multiple folders with id: " + folderId);
+        }
+        return folderList.get(0);
+    }
+}

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceAndPolicyLoaderUtil.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceAndPolicyLoaderUtil.java
@@ -23,4 +23,6 @@ public class ServiceAndPolicyLoaderUtil {
         }
         return folderList.get(0);
     }
+
+    private ServiceAndPolicyLoaderUtil(){}
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceAndPolicyLoaderUtil.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceAndPolicyLoaderUtil.java
@@ -55,9 +55,8 @@ public class ServiceAndPolicyLoaderUtil {
         int duplicateCounter = 2;
         String basePath = entity.getPath();
         String clonePath = basePath;
-        String sysProp = System.getProperty(HANDLE_DUPLICATE_NAMES);
 
-        if (sysProp != null && sysProp.equals("true")) {
+        if (Boolean.getBoolean(HANDLE_DUPLICATE_NAMES)) {
             while (bundleEntity.containsKey(clonePath)) {
                 Folderable service = bundleEntity.get(clonePath);
                 if (!service.getId().equals(entity.getId())

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoader.java
@@ -21,8 +21,7 @@ import org.w3c.dom.NodeList;
 import javax.inject.Singleton;
 import java.util.*;
 
-import static com.ca.apim.gateway.cagatewayconfig.bundle.loader.ServiceAndPolicyLoaderUtil.getFolder;
-import static com.ca.apim.gateway.cagatewayconfig.bundle.loader.ServiceAndPolicyLoaderUtil.getPath;
+import static com.ca.apim.gateway.cagatewayconfig.bundle.loader.ServiceAndPolicyLoaderUtil.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.*;
@@ -88,31 +87,6 @@ public class ServiceLoader implements BundleEntityLoader {
         }
 
         bundleService.put(serviceEntity.getPath(), serviceEntity);
-    }
-
-    /**
-     * Append a value to end of name of Service in a path if service name is found in bundle.
-     * Service Id must be different and must exist in the same folder.
-     *
-     * @param bundleService bundle containing original service
-     * @param serviceEntity duplicate service with same path and service name
-     * @return a path with a numerical value appended to the end to differentiate from original service
-     */
-    private String handleDuplicatePathName(Map<String, Service> bundleService, Service serviceEntity) {
-        int duplicateCounter = 2;
-        String basePath = serviceEntity.getPath();
-        String clonePath = basePath;
-        while (bundleService.containsKey(clonePath)) {
-            Service service = bundleService.get(clonePath);
-            if (!service.getId().equals(serviceEntity.getId())
-                    && (service.getParentFolderId().equals(serviceEntity.getParentFolderId())) ) {
-                clonePath = basePath + " (" + duplicateCounter + ")";
-                duplicateCounter++;
-            } else {
-                break;
-            }
-        }
-        return clonePath;
     }
 
     private void populateServiceEntity(Element service, Service serviceEntity, Map<String, Object> allProperties, Map<String, Object> properties) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoader.java
@@ -90,6 +90,14 @@ public class ServiceLoader implements BundleEntityLoader {
         bundleService.put(serviceEntity.getPath(), serviceEntity);
     }
 
+    /**
+     * Append a value to end of name of Service in a path if service name is found in bundle.
+     * Service Id must be different and must exist in the same folder.
+     *
+     * @param bundleService bundle containing original service
+     * @param serviceEntity duplicate service with same path and service name
+     * @return a path with a numerical value appended to the end to differentiate from original service
+     */
     private String handleDuplicatePathName(Map<String, Service> bundleService, Service serviceEntity) {
         int duplicateCounter = 2;
         String basePath = serviceEntity.getPath();

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoader.java
@@ -82,7 +82,7 @@ public class ServiceLoader implements BundleEntityLoader {
         Map<String, Service> bundleService = bundle.getServices();
 
         if (bundleService.containsKey(serviceEntity.getPath())) {
-            String duplicatePathName = handleDuplicate(bundleService, serviceEntity);
+            String duplicatePathName = handleDuplicatePathName(bundleService, serviceEntity);
             serviceEntity.setName(duplicatePathName.substring(duplicatePathName.lastIndexOf('/') + 1));
             serviceEntity.setPath(duplicatePathName);
         }
@@ -90,7 +90,7 @@ public class ServiceLoader implements BundleEntityLoader {
         bundleService.put(serviceEntity.getPath(), serviceEntity);
     }
 
-    private String handleDuplicate(Map<String, Service> bundleService, Service serviceEntity) {
+    private String handleDuplicatePathName(Map<String, Service> bundleService, Service serviceEntity) {
         int duplicateCounter = 2;
         String basePath = serviceEntity.getPath();
         String clonePath = basePath;
@@ -98,7 +98,7 @@ public class ServiceLoader implements BundleEntityLoader {
             Service service = bundleService.get(clonePath);
             if (!service.getId().equals(serviceEntity.getId())
                     && (service.getParentFolderId().equals(serviceEntity.getParentFolderId())) ) {
-                clonePath = basePath + "(" + duplicateCounter + ")";
+                clonePath = basePath + " (" + duplicateCounter + ")";
                 duplicateCounter++;
             } else {
                 break;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoader.java
@@ -12,7 +12,7 @@ import com.ca.apim.gateway.cagatewayconfig.beans.Service;
 import com.ca.apim.gateway.cagatewayconfig.beans.Wsdl;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils;
-import com.ca.apim.gateway.cagatewayconfig.util.string.EncodeDecodeUtils;
+import com.ca.apim.gateway.cagatewayconfig.util.string.CharacterBlacklistUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -21,6 +21,8 @@ import org.w3c.dom.NodeList;
 import javax.inject.Singleton;
 import java.util.*;
 
+import static com.ca.apim.gateway.cagatewayconfig.bundle.loader.ServiceAndPolicyLoaderUtil.getFolder;
+import static com.ca.apim.gateway.cagatewayconfig.bundle.loader.ServiceAndPolicyLoaderUtil.getPath;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.*;
@@ -31,13 +33,12 @@ public class ServiceLoader implements BundleEntityLoader {
     @Override
     public void load(Bundle bundle, Element element) {
         final Element service = getSingleChildElement(getSingleChildElement(element, RESOURCE), SERVICE);
-        final String servicePath = getSingleChildElement(element, NAME).getTextContent();
 
         final Element serviceDetails = getSingleChildElement(service, SERVICE_DETAIL);
         final String id = serviceDetails.getAttribute(ATTRIBUTE_ID);
         final String folderId = serviceDetails.getAttribute(ATTRIBUTE_FOLDER_ID);
         Element nameElement = getSingleChildElement(serviceDetails, NAME);
-        final String name = EncodeDecodeUtils.encodePath(nameElement.getTextContent());
+        final String name = CharacterBlacklistUtil.filterAndReplace(nameElement.getTextContent());
 
         Element servicePropertiesElement = getSingleChildElement(serviceDetails, PROPERTIES);
         Map<String, Object> allProperties = BuilderUtils.mapPropertiesElements(servicePropertiesElement, PROPERTIES);
@@ -46,11 +47,12 @@ public class ServiceLoader implements BundleEntityLoader {
         populateServiceEntity(service, serviceEntity, allProperties, properties);
         boolean isSoapService = serviceEntity.getWsdl() != null;
 
+        Folder parentFolder = getFolder(bundle, folderId);
+
         serviceEntity.setName(name);
         serviceEntity.setId(id);
-        Folder folder = new Folder();
-        folder.setId(folderId);
-        serviceEntity.setParentFolder(folder);
+        serviceEntity.setPath(getPath(parentFolder, name));
+        serviceEntity.setParentFolder(parentFolder);
         serviceEntity.setServiceDetailsElement(serviceDetails);
 
         Element serviceMappingsElement = getSingleChildElement(serviceEntity.getServiceDetailsElement(), SERVICE_MAPPINGS);
@@ -77,7 +79,32 @@ public class ServiceLoader implements BundleEntityLoader {
         serviceEntity.setHttpMethods(httpMethods);
         serviceEntity.setProperties(properties);
 
-        bundle.getServices().put(servicePath, serviceEntity);
+        Map<String, Service> bundleService = bundle.getServices();
+
+        if (bundleService.containsKey(serviceEntity.getPath())) {
+            String duplicatePathName = handleDuplicate(bundleService, serviceEntity);
+            serviceEntity.setName(duplicatePathName.substring(duplicatePathName.lastIndexOf("/") + 1));
+            serviceEntity.setPath(duplicatePathName);
+        }
+
+        bundleService.put(serviceEntity.getPath(), serviceEntity);
+    }
+
+    private String handleDuplicate(Map<String, Service> bundleService, Service serviceEntity) {
+        int duplicateCounter = 2;
+        String basePath = serviceEntity.getPath();
+        String clonePath = basePath;
+        while (bundleService.containsKey(clonePath)) {
+            Service service = bundleService.get(clonePath);
+            if ( (service.getId() != serviceEntity.getId())
+                    && (service.getParentFolderId().equals(serviceEntity.getParentFolderId())) ) {
+                clonePath = basePath + "(" + duplicateCounter + ")";
+                duplicateCounter++;
+            } else {
+                break;
+            }
+        }
+        return clonePath;
     }
 
     private void populateServiceEntity(Element service, Service serviceEntity, Map<String, Object> allProperties, Map<String, Object> properties) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoader.java
@@ -83,7 +83,7 @@ public class ServiceLoader implements BundleEntityLoader {
 
         if (bundleService.containsKey(serviceEntity.getPath())) {
             String duplicatePathName = handleDuplicate(bundleService, serviceEntity);
-            serviceEntity.setName(duplicatePathName.substring(duplicatePathName.lastIndexOf("/") + 1));
+            serviceEntity.setName(duplicatePathName.substring(duplicatePathName.lastIndexOf('/') + 1));
             serviceEntity.setPath(duplicatePathName);
         }
 
@@ -96,7 +96,7 @@ public class ServiceLoader implements BundleEntityLoader {
         String clonePath = basePath;
         while (bundleService.containsKey(clonePath)) {
             Service service = bundleService.get(clonePath);
-            if ( (service.getId() != serviceEntity.getId())
+            if (!service.getId().equals(serviceEntity.getId())
                     && (service.getParentFolderId().equals(serviceEntity.getParentFolderId())) ) {
                 clonePath = basePath + "(" + duplicateCounter + ")";
                 duplicateCounter++;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/TemplatizedBundle.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/TemplatizedBundle.java
@@ -8,7 +8,9 @@ package com.ca.apim.gateway.cagatewayconfig.environment;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.Collections;
 
 /**
  * Represents a Templatized Deployment Bundle and provide read/write to its contents.
@@ -37,7 +39,7 @@ interface TemplatizedBundle {
         @Override
         public String getContents() {
             try {
-                return new String(Files.readAllBytes(this.originalFile.toPath()));
+                return new String(Files.readAllBytes(this.originalFile.toPath()), StandardCharsets.UTF_8);
             } catch (IOException e) {
                 throw new BundleDetemplatizeException("Could not read bundle file: " + originalFile.getName(), e);
             }
@@ -46,7 +48,7 @@ interface TemplatizedBundle {
         @Override
         public void writeContents(String content) {
             try {
-                Files.write(newFile.toPath(), content.getBytes());
+                Files.write(newFile.toPath(), Collections.singleton(content), StandardCharsets.UTF_8);
             } catch (IOException e) {
                 throw new BundleDetemplatizeException("Could not write detemplatized bundle to: " + newFile.getName(), e);
             }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/TemplatizedBundle.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/TemplatizedBundle.java
@@ -31,7 +31,6 @@ interface TemplatizedBundle {
 
         private final File newFile;
         private final File originalFile;
-        private final Charset defaultCharSet = StandardCharsets.UTF_8;
 
         FileTemplatizedBundle(File originalFile, File newFile) {
             this.newFile = newFile;
@@ -41,7 +40,7 @@ interface TemplatizedBundle {
         @Override
         public String getContents() {
             try {
-                return new String(Files.readAllBytes(this.originalFile.toPath()), defaultCharSet);
+                return new String(Files.readAllBytes(this.originalFile.toPath()), StandardCharsets.UTF_8);
             } catch (IOException e) {
                 throw new BundleDetemplatizeException("Could not read bundle file: " + originalFile.getName(), e);
             }
@@ -50,7 +49,7 @@ interface TemplatizedBundle {
         @Override
         public void writeContents(String content) {
             try {
-                Files.write(newFile.toPath(), Collections.singleton(content), defaultCharSet);
+                Files.write(newFile.toPath(), Collections.singleton(content), StandardCharsets.UTF_8);
             } catch (IOException e) {
                 throw new BundleDetemplatizeException("Could not write detemplatized bundle to: " + newFile.getName(), e);
             }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/TemplatizedBundle.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/TemplatizedBundle.java
@@ -8,6 +8,7 @@ package com.ca.apim.gateway.cagatewayconfig.environment;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collections;
@@ -30,6 +31,7 @@ interface TemplatizedBundle {
 
         private final File newFile;
         private final File originalFile;
+        private final Charset defaultCharSet = StandardCharsets.UTF_8;
 
         FileTemplatizedBundle(File originalFile, File newFile) {
             this.newFile = newFile;
@@ -39,7 +41,7 @@ interface TemplatizedBundle {
         @Override
         public String getContents() {
             try {
-                return new String(Files.readAllBytes(this.originalFile.toPath()), StandardCharsets.UTF_8);
+                return new String(Files.readAllBytes(this.originalFile.toPath()), defaultCharSet);
             } catch (IOException e) {
                 throw new BundleDetemplatizeException("Could not read bundle file: " + originalFile.getName(), e);
             }
@@ -48,7 +50,7 @@ interface TemplatizedBundle {
         @Override
         public void writeContents(String content) {
             try {
-                Files.write(newFile.toPath(), Collections.singleton(content), StandardCharsets.UTF_8);
+                Files.write(newFile.toPath(), Collections.singleton(content), defaultCharSet);
             } catch (IOException e) {
                 throw new BundleDetemplatizeException("Could not write detemplatized bundle to: " + newFile.getName(), e);
             }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/environment/CharacterBlacklist.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/environment/CharacterBlacklist.java
@@ -1,0 +1,40 @@
+package com.ca.apim.gateway.cagatewayconfig.util.environment;
+
+import java.lang.reflect.Field;
+import java.util.HashSet;
+import java.util.stream.Stream;
+
+public class CharacterBlacklist {
+
+    public static final char LESS_THAN = '<';
+    public static final char GREATER_THAN = '>';
+    public static final char COLON = ':';
+    public static final char DOUBLE_QUOTE = '\'';
+    public static final char FORWARD_SLASH = '/';
+    public static final char BACK_SLASH = '\\';
+    public static final char PIPE = '|';
+    public static final char QUESTION_MARK = '?';
+    public static final char ASTERISK = '*';
+    public static final char NULL_CHAR = '\0';
+
+    public static HashSet<Character> getCharBlacklist() {
+        Field[] fields = CharacterBlacklist.class.getFields();
+        CharacterBlacklist cblInstance = new CharacterBlacklist();
+        HashSet<Character> charBlackList = new HashSet<>();
+
+        Stream.of(fields).forEach(field -> {
+            try {
+                char fieldValue = (Character) field.get(cblInstance);
+                charBlackList.add(fieldValue);
+            } catch (IllegalAccessException e) {
+                e.printStackTrace();
+            }
+        });
+
+        return charBlackList;
+    }
+
+    private CharacterBlacklist() {
+        //
+    }
+}

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/environment/CharacterBlacklist.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/environment/CharacterBlacklist.java
@@ -5,8 +5,13 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.stream.Stream;
 
+/**
+ * Contains all blacklisted characters for file names in Windows and UNIX. Purpose of class is to provide all
+ * values in a set.
+ */
 public class CharacterBlacklist {
 
+    // Windows
     public static final char LESS_THAN = '<';
     public static final char GREATER_THAN = '>';
     public static final char COLON = ':';
@@ -16,8 +21,15 @@ public class CharacterBlacklist {
     public static final char PIPE = '|';
     public static final char QUESTION_MARK = '?';
     public static final char ASTERISK = '*';
+
+    // Unix
     public static final char NULL_CHAR = '\0';
 
+    /**
+     * Retrieve set of blacklist characters
+     *
+     * @return set with all constants in the class. Constants are blacklisted characters.
+     */
     public static Set getCharBlacklist() {
         Field[] fields = CharacterBlacklist.class.getFields();
         CharacterBlacklist cblInstance = new CharacterBlacklist();
@@ -35,7 +47,5 @@ public class CharacterBlacklist {
         return charBlackList;
     }
 
-    private CharacterBlacklist() {
-        //
-    }
+    private CharacterBlacklist() {}
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/environment/CharacterBlacklist.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/environment/CharacterBlacklist.java
@@ -15,7 +15,7 @@ public class CharacterBlacklist {
     public static final char LESS_THAN = '<';
     public static final char GREATER_THAN = '>';
     public static final char COLON = ':';
-    public static final char DOUBLE_QUOTE = '\'';
+    public static final char DOUBLE_QUOTE = '\"';
     public static final char FORWARD_SLASH = '/';
     public static final char BACK_SLASH = '\\';
     public static final char PIPE = '|';

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/environment/CharacterBlacklist.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/environment/CharacterBlacklist.java
@@ -25,13 +25,14 @@ public class CharacterBlacklist {
     // Unix
     public static final char NULL_CHAR = '\0';
 
+    private static final Field[] fields = CharacterBlacklist.class.getFields();
+
     /**
      * Retrieve set of blacklist characters
      *
-     * @return set with all constants in the class. Constants are blacklisted characters.
+     * @return Character Set with all constants in the class. Constants are blacklisted characters.
      */
-    public static Set getCharBlacklist() {
-        Field[] fields = CharacterBlacklist.class.getFields();
+    public static Set<Character> getCharBlacklist() {
         CharacterBlacklist cblInstance = new CharacterBlacklist();
         Set<Character> charBlackList = new HashSet<>();
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/environment/CharacterBlacklist.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/environment/CharacterBlacklist.java
@@ -2,6 +2,7 @@ package com.ca.apim.gateway.cagatewayconfig.util.environment;
 
 import java.lang.reflect.Field;
 import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Stream;
 
 public class CharacterBlacklist {
@@ -17,17 +18,17 @@ public class CharacterBlacklist {
     public static final char ASTERISK = '*';
     public static final char NULL_CHAR = '\0';
 
-    public static HashSet<Character> getCharBlacklist() {
+    public static Set getCharBlacklist() {
         Field[] fields = CharacterBlacklist.class.getFields();
         CharacterBlacklist cblInstance = new CharacterBlacklist();
-        HashSet<Character> charBlackList = new HashSet<>();
+        Set<Character> charBlackList = new HashSet<>();
 
         Stream.of(fields).forEach(field -> {
             try {
                 char fieldValue = (Character) field.get(cblInstance);
                 charBlackList.add(fieldValue);
             } catch (IllegalAccessException e) {
-                e.printStackTrace();
+                throw new IllegalArgumentException("Error accessing blacklist character field " + field.getName(), e);
             }
         });
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/environment/CharacterBlacklist.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/environment/CharacterBlacklist.java
@@ -25,20 +25,25 @@ public class CharacterBlacklist {
     // Unix
     public static final char NULL_CHAR = '\0';
 
-    private static final Field[] fields = CharacterBlacklist.class.getFields();
+    private static final Set<Character> charBlackList = initializeCharBlacklist();
 
     /**
      * Retrieve set of blacklist characters
      *
      * @return Character Set with all constants in the class. Constants are blacklisted characters.
      */
+
     public static Set<Character> getCharBlacklist() {
-        CharacterBlacklist cblInstance = new CharacterBlacklist();
+        return charBlackList;
+    }
+
+    private static Set<Character> initializeCharBlacklist() {
+        Field[] fields = CharacterBlacklist.class.getFields();
         Set<Character> charBlackList = new HashSet<>();
 
         Stream.of(fields).forEach(field -> {
             try {
-                char fieldValue = (Character) field.get(cblInstance);
+                char fieldValue = (Character) field.get(CharacterBlacklist.class);
                 charBlackList.add(fieldValue);
             } catch (IllegalAccessException e) {
                 throw new IllegalArgumentException("Error accessing blacklist character field " + field.getName(), e);

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklist.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklist.java
@@ -6,27 +6,47 @@
 
 package com.ca.apim.gateway.cagatewayconfig.util.string;
 
-public class EncodeDecodeUtils {
+import java.util.Set;
 
-    private EncodeDecodeUtils() {
+import static com.ca.apim.gateway.cagatewayconfig.util.environment.CharacterBlacklist.getCharBlacklist;
+
+public class CharacterBlacklistFilter {
+
+    private CharacterBlacklistFilter() {
     }
 
     public static String encodePath(String pathToEncode) {
         if (pathToEncode.contains("_¯") || pathToEncode.contains("¯_")) {
             throw new IllegalArgumentException("Illegal characters in path. Cannot contain '_¯' or '¯_': " + pathToEncode);
         }
-        pathToEncode = pathToEncode.replaceAll("/", "_¯");
-        pathToEncode = pathToEncode.replaceAll("\\\\", "¯_");
+
+        Set<Character> charBlacklist = getCharBlacklist();
+
+        for (char c : pathToEncode.toCharArray()) {
+            if (charBlacklist.contains(c)) {
+                pathToEncode = pathToEncode.replace(Character.toString(c),"-");
+            }
+        }
+
         return pathToEncode;
     }
 
     public static String decodePath(String pathToDecode) {
         pathToDecode = pathToDecode.replaceAll("_¯", "/");
         pathToDecode = pathToDecode.replaceAll("¯_", "\\\\");
+        getCharBlacklist();
         return pathToDecode;
     }
 
     public static boolean containsInvalidCharacter(String name) {
-        return name.contains("_¯") || name.contains("¯_") || name.contains("\\") || name.contains("/");
+        Set<Character> charBlacklist = getCharBlacklist();
+
+        for (char c : name.toCharArray()) {
+            if (charBlacklist.contains(c)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtil.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtil.java
@@ -10,32 +10,21 @@ import java.util.Set;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.environment.CharacterBlacklist.getCharBlacklist;
 
-public class CharacterBlacklistFilter {
+public class CharacterBlacklistUtil {
 
-    private CharacterBlacklistFilter() {
+    private CharacterBlacklistUtil() {
     }
 
-    public static String encodePath(String pathToEncode) {
-        if (pathToEncode.contains("_¯") || pathToEncode.contains("¯_")) {
-            throw new IllegalArgumentException("Illegal characters in path. Cannot contain '_¯' or '¯_': " + pathToEncode);
-        }
-
+    public static String filterAndReplace(String string) {
         Set<Character> charBlacklist = getCharBlacklist();
 
-        for (char c : pathToEncode.toCharArray()) {
+        for (char c : string.toCharArray()) {
             if (charBlacklist.contains(c)) {
-                pathToEncode = pathToEncode.replace(Character.toString(c),"-");
+                string = string.replace(Character.toString(c),"-");
             }
         }
 
-        return pathToEncode;
-    }
-
-    public static String decodePath(String pathToDecode) {
-        pathToDecode = pathToDecode.replaceAll("_¯", "/");
-        pathToDecode = pathToDecode.replaceAll("¯_", "\\\\");
-        getCharBlacklist();
-        return pathToDecode;
+        return string;
     }
 
     public static boolean containsInvalidCharacter(String name) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtil.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtil.java
@@ -10,8 +10,17 @@ import java.util.Set;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.environment.CharacterBlacklist.getCharBlacklist;
 
+/**
+ * Utility class for Character Blacklist. Purpose is to apply functions to the constants found in CharacterBlacklist
+ */
 public class CharacterBlacklistUtil {
 
+    /**
+     * Find blacklist characters and replace with value '-'
+     *
+     * @param string with invalid characters
+     * @return a string stripped of all invalid characters and replaced with value '-'
+     */
     public static String filterAndReplace(String string) {
         Set<Character> charBlacklist = getCharBlacklist();
 
@@ -24,6 +33,11 @@ public class CharacterBlacklistUtil {
         return string;
     }
 
+    /**
+     *
+     * @param name with invalid characters
+     * @return boolean indicating whether a invalid character exist
+     */
     public static boolean containsInvalidCharacter(String name) {
         Set<Character> charBlacklist = getCharBlacklist();
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtil.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtil.java
@@ -12,9 +12,6 @@ import static com.ca.apim.gateway.cagatewayconfig.util.environment.CharacterBlac
 
 public class CharacterBlacklistUtil {
 
-    private CharacterBlacklistUtil() {
-    }
-
     public static String filterAndReplace(String string) {
         Set<Character> charBlacklist = getCharBlacklist();
 
@@ -38,4 +35,6 @@ public class CharacterBlacklistUtil {
 
         return false;
     }
+
+    private CharacterBlacklistUtil() {}
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtil.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtil.java
@@ -23,14 +23,40 @@ public class CharacterBlacklistUtil {
      */
     public static String filterAndReplace(String string) {
         Set<Character> charBlacklist = getCharBlacklist();
+        final char replacementChar = '-';
+        StringBuilder processedString = new StringBuilder();
 
         for (char c : string.toCharArray()) {
             if (charBlacklist.contains(c)) {
-                string = string.replace(Character.toString(c),"-");
+                processedString.append(replacementChar);
+            } else {
+                processedString.append(c);
             }
         }
 
-        return string;
+        return compressString(processedString.toString(), replacementChar);
+    }
+
+    /**
+     * Compress repeating characters in String
+     *
+     * @param string with repeating characters
+     * @param replacementChar to replace in string
+     * @return string with selected repeating character removed
+     */
+    private static String compressString(String string, char replacementChar) {
+        StringBuilder processedString = new StringBuilder(string);
+        int iterator = 0;
+
+        while (iterator < processedString.length() - 1) {
+            if (processedString.charAt(iterator) == replacementChar && processedString.charAt(iterator + 1) == replacementChar) {
+                processedString.deleteCharAt(iterator);
+            } else {
+                iterator++;
+            }
+        }
+
+        return processedString.toString();
     }
 
     /**

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtil.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtil.java
@@ -14,6 +14,7 @@ import static com.ca.apim.gateway.cagatewayconfig.util.environment.CharacterBlac
  * Utility class for Character Blacklist. Purpose is to apply functions to the constants found in CharacterBlacklist
  */
 public class CharacterBlacklistUtil {
+    private static final char REPLACEMENT_CHAR = '-';
 
     /**
      * Find blacklist characters and replace with value '-'
@@ -23,18 +24,14 @@ public class CharacterBlacklistUtil {
      */
     public static String filterAndReplace(String string) {
         Set<Character> charBlacklist = getCharBlacklist();
-        final char replacementChar = '-';
-        StringBuilder processedString = new StringBuilder();
 
         for (char c : string.toCharArray()) {
             if (charBlacklist.contains(c)) {
-                processedString.append(replacementChar);
-            } else {
-                processedString.append(c);
+                string = string.replace(c, REPLACEMENT_CHAR);
             }
         }
 
-        return compressString(processedString.toString(), replacementChar);
+        return compressString(string, REPLACEMENT_CHAR);
     }
 
     /**

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/FolderEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/FolderEntityBuilderTest.java
@@ -11,7 +11,7 @@ import com.ca.apim.gateway.cagatewayconfig.beans.Folder;
 import com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleType;
 import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
-import com.ca.apim.gateway.cagatewayconfig.util.string.EncodeDecodeUtils;
+import com.ca.apim.gateway.cagatewayconfig.util.string.CharacterBlacklistUtil;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
 import com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
@@ -37,7 +37,7 @@ class FolderEntityBuilderTest {
     private static final IdGenerator ID_GENERATOR = new IdGenerator();
     private static final String FOLDER_1 = "Folder1";
     private static final String FOLDER_2 = "Folder2";
-    private static final String FOLDER_3 = "Fo-_¯-¯_-lder3";
+    private static final String FOLDER_3 = "Folder3";
 
     @Test
     void buildFromEmptyBundle_noFolders() {
@@ -88,9 +88,9 @@ class FolderEntityBuilderTest {
         entitiesMap.forEach((k, entity) -> {
             k = Folder.ROOT_FOLDER_NAME.equals(k) ? EMPTY : k;
 
-            Folder folder = bundle.getFolders().get(EncodeDecodeUtils.encodePath(k));
+            Folder folder = bundle.getFolders().get(k);
             assertNotNull(folder);
-            assertEquals(EncodeDecodeUtils.decodePath(folder.getName()), entity.getName());
+            assertEquals(folder.getName(), CharacterBlacklistUtil.filterAndReplace(entity.getName()));
             assertNotNull(entity.getId());
             assertNotNull(entity.getXml());
             assertEquals(EntityTypes.FOLDER_TYPE, entity.getType());

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilderTest.java
@@ -11,7 +11,6 @@ import com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleTy
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingProperties;
 import com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants;
-import com.ca.apim.gateway.cagatewayconfig.util.string.EncodeDecodeUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
 import com.google.common.collect.ImmutableMap;
@@ -510,25 +509,6 @@ class PolicyEntityBuilderTest {
         Entity policyEntity = policyEntityBuilder.buildPolicyEntity(policyToBuild, bundle, document);
 
         assertEquals(policyToBuild.getId(), policyEntity.getId());
-    }
-
-    @Test
-    void buildPolicyEntityTestEncodedPath() {
-        PolicyEntityBuilder policyEntityBuilder = new PolicyEntityBuilder(DocumentTools.INSTANCE);
-
-        Policy policyToBuild = new Policy();
-        policyToBuild.setName("policy-_¯-¯_");
-        policyToBuild.setPath("policy-_¯-¯_");
-        policyToBuild.setId("policy-id");
-        policyToBuild.setGuid("policy-guid-123");
-        Folder parentFolder = new Folder();
-        parentFolder.setId("folder-id");
-        policyToBuild.setParentFolder(parentFolder);
-
-        Entity policyEntity = policyEntityBuilder.buildPolicyEntity(policyToBuild, bundle, document);
-
-        assertEquals(policyToBuild.getId(), policyEntity.getId());
-        assertEquals(EncodeDecodeUtils.decodePath(policyToBuild.getName()), policyEntity.getName());
     }
 
     @Test

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ServiceEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ServiceEntityBuilderTest.java
@@ -8,7 +8,6 @@ package com.ca.apim.gateway.cagatewayconfig.bundle.builder;
 
 import com.ca.apim.gateway.cagatewayconfig.beans.*;
 import com.ca.apim.gateway.cagatewayconfig.util.IdGenerator;
-import com.ca.apim.gateway.cagatewayconfig.util.string.EncodeDecodeUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
 import org.jetbrains.annotations.NotNull;
@@ -90,37 +89,6 @@ class ServiceEntityBuilderTest {
         Entity serviceEntity = services.get(0);
 
         verifyService(service, serviceEntity, 1, "service" + 1);
-    }
-
-    @Test
-    void buildOneServicesEncodedPath() throws DocumentParseException {
-        ServiceEntityBuilder builder = new ServiceEntityBuilder(DocumentTools.INSTANCE, new IdGenerator());
-
-        Bundle bundle = new Bundle();
-
-        Folder serviceParentFolder = setUpFolderAndPolicy(bundle, "my/policy-_¯-¯_/_¯-¯_-path.xml", "_¯-¯_-path");
-
-        Service service = new Service();
-        service.setHttpMethods(Stream.of("POST", "GET").collect(Collectors.toSet()));
-        service.setUrl("/my/service/url");
-        service.setPolicy("my/policy-_¯-¯_/_¯-¯_-path.xml");
-        service.setParentFolder(serviceParentFolder);
-        service.setProperties(new HashMap<String, Object>() {{
-            put("key1", "value1");
-            put("ENV.key.environment", "something");
-        }});
-
-        bundle.putAllServices(new HashMap<String, Service>() {{
-            put("my/service-_¯-¯_/_¯-¯_-path", service);
-        }});
-
-        List<Entity> services = builder.build(bundle, EntityBuilder.BundleType.DEPLOYMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
-
-        assertEquals(1, services.size());
-
-        Entity serviceEntity = services.get(0);
-
-        verifyService(service, serviceEntity, 1, EncodeDecodeUtils.decodePath("_¯-¯_-path"));
     }
 
     @Test

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoaderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoaderTest.java
@@ -12,7 +12,6 @@ import com.ca.apim.gateway.cagatewayconfig.beans.Service;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
 import org.junit.jupiter.api.Test;
-import org.w3c.dom.Element;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -104,6 +103,7 @@ class ServiceLoaderTest {
         folder.setName(TEST_FOLDER);
         folder.setPath(TEST_FOLDER);
         bundle.getFolders().put(TEST_FOLDER, folder);
+        System.setProperty("exportDuplicate", "true");
 
         loader.load(bundle, createServiceXml(DocumentTools.INSTANCE.getDocumentBuilder().newDocument(),
                 true, false, false, false));
@@ -124,6 +124,7 @@ class ServiceLoaderTest {
         folder.setName(TEST_FOLDER);
         folder.setPath(TEST_FOLDER);
         bundle.getFolders().put(TEST_FOLDER, folder);
+        System.setProperty("exportDuplicate", "true");
 
         loader.load(bundle, createServiceXml(
                 DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), true, true, false, false

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoaderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoaderTest.java
@@ -96,6 +96,26 @@ class ServiceLoaderTest {
     }
 
     @Test
+    void loadDuplicateService() {
+        ServiceLoader loader = new ServiceLoader();
+        Bundle bundle = new Bundle();
+        Folder folder = new Folder();
+        folder.setId(TEST_FOLDER);
+        folder.setName(TEST_FOLDER);
+        folder.setPath(TEST_FOLDER);
+        bundle.getFolders().put(TEST_FOLDER, folder);
+
+        loader.load(bundle, createServiceXml(DocumentTools.INSTANCE.getDocumentBuilder().newDocument(),
+                true, false, false, false));
+
+        loader.load(bundle, createServiceXml(DocumentTools.INSTANCE.getDocumentBuilder().newDocument(),
+                true, false, false, false));
+
+        assertFalse(bundle.getServices().isEmpty());
+        assertEquals(1, bundle.getServices().size());
+    }
+
+    @Test
     void soapServiceLoad() {
         ServiceLoader loader = new ServiceLoader();
         Bundle bundle = new Bundle();

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoaderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoaderTest.java
@@ -7,6 +7,7 @@
 package com.ca.apim.gateway.cagatewayconfig.bundle.loader;
 
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
+import com.ca.apim.gateway.cagatewayconfig.beans.Folder;
 import com.ca.apim.gateway.cagatewayconfig.beans.Service;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
@@ -21,17 +22,24 @@ import static com.ca.apim.gateway.cagatewayconfig.util.TestUtils.createServiceXm
 import static org.junit.jupiter.api.Assertions.*;
 
 class ServiceLoaderTest {
+    private static final String TEST_FOLDER = "folder";
 
     @Test
     void load() {
         ServiceLoader loader = new ServiceLoader();
         Bundle bundle = new Bundle();
+        Folder folder = new Folder();
+        folder.setId(TEST_FOLDER);
+        folder.setName(TEST_FOLDER);
+        folder.setPath(TEST_FOLDER);
+        bundle.getFolders().put(TEST_FOLDER, folder);
+
         loader.load(bundle, createServiceXml(DocumentTools.INSTANCE.getDocumentBuilder().newDocument(),
                 true, false, false, false));
 
         assertFalse(bundle.getServices().isEmpty());
         assertEquals(1, bundle.getServices().size());
-        Service service = bundle.getServices().get("/folder/service");
+        Service service = bundle.getServices().get(TEST_FOLDER + "/service");
         assertNotNull(service);
         assertEquals("service", service.getName());
         assertEquals("/service", service.getUrl());
@@ -53,13 +61,19 @@ class ServiceLoaderTest {
     void soapServiceLoad() {
         ServiceLoader loader = new ServiceLoader();
         Bundle bundle = new Bundle();
+        Folder folder = new Folder();
+        folder.setId(TEST_FOLDER);
+        folder.setName(TEST_FOLDER);
+        folder.setPath(TEST_FOLDER);
+        bundle.getFolders().put(TEST_FOLDER, folder);
+
         loader.load(bundle, createServiceXml(
                 DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), true, true, false, false
         ));
 
         assertFalse(bundle.getServices().isEmpty());
         assertEquals(1, bundle.getServices().size());
-        Service service = bundle.getServices().get("/folder/service");
+        Service service = bundle.getServices().get(TEST_FOLDER + "/service");
         assertNotNull(service);
         assertEquals("service", service.getName());
         assertEquals("/soap-service", service.getUrl());

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoaderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoaderTest.java
@@ -66,6 +66,7 @@ class ServiceLoaderTest {
         folder.setName(TEST_FOLDER);
         folder.setPath(TEST_FOLDER);
         bundle.getFolders().put(TEST_FOLDER, folder);
+        System.setProperty(ServiceAndPolicyLoaderUtil.HANDLE_DUPLICATE_NAMES, "true");
 
         loader.load(bundle, createServiceXml(DocumentTools.INSTANCE.getDocumentBuilder().newDocument(),
                 true, false, false, false));
@@ -73,6 +74,8 @@ class ServiceLoaderTest {
         //Load duplicate with different id
         loader.load(bundle, createServiceXml(DocumentTools.INSTANCE.getDocumentBuilder().newDocument(),
                 true, true, false, false));
+
+        System.clearProperty(ServiceAndPolicyLoaderUtil.HANDLE_DUPLICATE_NAMES);
 
         assertFalse(bundle.getServices().isEmpty());
         assertEquals(2, bundle.getServices().size());
@@ -95,7 +98,7 @@ class ServiceLoaderTest {
     }
 
     @Test
-    void loadDuplicateService() {
+    void loadDuplicateServiceWithPropDisabled() {
         ServiceLoader loader = new ServiceLoader();
         Bundle bundle = new Bundle();
         Folder folder = new Folder();
@@ -103,16 +106,14 @@ class ServiceLoaderTest {
         folder.setName(TEST_FOLDER);
         folder.setPath(TEST_FOLDER);
         bundle.getFolders().put(TEST_FOLDER, folder);
-        System.setProperty("exportDuplicate", "true");
 
         loader.load(bundle, createServiceXml(DocumentTools.INSTANCE.getDocumentBuilder().newDocument(),
                 true, false, false, false));
 
-        loader.load(bundle, createServiceXml(DocumentTools.INSTANCE.getDocumentBuilder().newDocument(),
-                true, false, false, false));
-
-        assertFalse(bundle.getServices().isEmpty());
-        assertEquals(1, bundle.getServices().size());
+        assertThrows(BundleLoadException.class, () -> loader.load(bundle,
+            createServiceXml(DocumentTools.INSTANCE.getDocumentBuilder().newDocument(),
+                true, false, false, false))
+        );
     }
 
     @Test
@@ -124,7 +125,6 @@ class ServiceLoaderTest {
         folder.setName(TEST_FOLDER);
         folder.setPath(TEST_FOLDER);
         bundle.getFolders().put(TEST_FOLDER, folder);
-        System.setProperty("exportDuplicate", "true");
 
         loader.load(bundle, createServiceXml(
                 DocumentTools.INSTANCE.getDocumentBuilder().newDocument(), true, true, false, false

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistTest.java
@@ -10,15 +10,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class EncodeDecodeUtilsTest {
+class CharacterBlacklistTest {
 
     @Test
-    void decodePath() {
-        assertEquals("example/folder-/-\\-slashed/example-/-\\-slashed.xml", EncodeDecodeUtils.decodePath("example/folder-_¯-¯_-slashed/example-_¯-¯_-slashed.xml"));
-    }
-
-    //@Test
-    void encodePath() {
-        assertEquals("example-_¯-¯_-slashed.xml", EncodeDecodeUtils.encodePath("example-/-\\-slashed.xml"));
+    void filterAndReplace() {
+        assertEquals("example-----slashed.xml", CharacterBlacklistUtil.filterAndReplace("example-/-\\-slashed.xml"));
     }
 }

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistTest.java
@@ -17,7 +17,7 @@ class EncodeDecodeUtilsTest {
         assertEquals("example/folder-/-\\-slashed/example-/-\\-slashed.xml", EncodeDecodeUtils.decodePath("example/folder-_¯-¯_-slashed/example-_¯-¯_-slashed.xml"));
     }
 
-    @Test
+    //@Test
     void encodePath() {
         assertEquals("example-_¯-¯_-slashed.xml", EncodeDecodeUtils.encodePath("example-/-\\-slashed.xml"));
     }

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtilTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtilTest.java
@@ -8,12 +8,18 @@ package com.ca.apim.gateway.cagatewayconfig.util.string;
 
 import org.junit.jupiter.api.Test;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-class CharacterBlacklistTest {
+class CharacterBlacklistUtilTest {
 
     @Test
     void filterAndReplace() {
         assertEquals("example-----slashed.xml", CharacterBlacklistUtil.filterAndReplace("example-/-\\-slashed.xml"));
+    }
+
+    @Test
+    void containsInvalidCharacter() {
+        assertTrue(CharacterBlacklistUtil.containsInvalidCharacter("example-/-\\-slashed.xml"));
     }
 }

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtilTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtilTest.java
@@ -15,7 +15,12 @@ class CharacterBlacklistUtilTest {
 
     @Test
     void filterAndReplace() {
-        assertEquals("example-----slashed.xml", CharacterBlacklistUtil.filterAndReplace("example-/-\\-slashed.xml"));
+        assertEquals("example-slashed.xml", CharacterBlacklistUtil.filterAndReplace("example-/-\\-slashed.xml"));
+    }
+
+    @Test
+    void testStringCompressionOnRepeatingHyphens() {
+        assertEquals("example-", CharacterBlacklistUtil.filterAndReplace("example-------"));
     }
 
     @Test

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtilTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtilTest.java
@@ -6,9 +6,13 @@
 
 package com.ca.apim.gateway.cagatewayconfig.util.string;
 
+import com.ca.apim.gateway.cagatewayconfig.util.environment.CharacterBlacklist;
 import org.junit.jupiter.api.Test;
 
+import java.util.stream.Stream;
+
 import static junit.framework.TestCase.assertTrue;
+import static junit.framework.TestCase.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CharacterBlacklistUtilTest {
@@ -19,12 +23,23 @@ class CharacterBlacklistUtilTest {
     }
 
     @Test
-    void testStringCompressionOnRepeatingHyphens() {
+    void stringCompressionOnRepeatingHyphens() {
         assertEquals("example-", CharacterBlacklistUtil.filterAndReplace("example-------"));
     }
 
     @Test
     void containsInvalidCharacter() {
-        assertTrue(CharacterBlacklistUtil.containsInvalidCharacter("example-/-\\-slashed.xml"));
+        Character[] blacklistChar = {CharacterBlacklist.LESS_THAN, CharacterBlacklist.GREATER_THAN, CharacterBlacklist.COLON, CharacterBlacklist.DOUBLE_QUOTE,
+            CharacterBlacklist.FORWARD_SLASH, CharacterBlacklist.BACK_SLASH, CharacterBlacklist.PIPE, CharacterBlacklist.QUESTION_MARK, CharacterBlacklist.ASTERISK,
+            CharacterBlacklist.NULL_CHAR};
+
+        Stream.of(blacklistChar).forEach(c -> {
+            assertTrue(CharacterBlacklistUtil.containsInvalidCharacter("example with invalid character " + c));
+        });
+    }
+
+    @Test
+    void containsNoInvalidCharacter() {
+        assertFalse(CharacterBlacklistUtil.containsInvalidCharacter("example with no invalid characters"));
     }
 }


### PR DESCRIPTION
Fixes US581740

## Proposed Changes
* All exported policies names are updated by replacing blacklist characters to "-"
* Duplicate "-" are now compressed if found in policy names. E.g. "----example----" to "-example-"
* Supports UTF-8 characters for filenames
