### PR TITLE
DE414136 XML character escaping/unescaping

### DIFF
--- a/config-builder/build.gradle
+++ b/config-builder/build.gradle
@@ -20,4 +20,5 @@ dependencies {
     compile 'org.reflections:reflections:0.9.11'
     compile 'org.apache.httpcomponents:httpclient:4.5.5'
     runtime 'org.slf4j:slf4j-simple:1.7.25'
+    compile 'org.apache.commons:commons-text:1.6'
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
@@ -16,6 +16,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMap.Builder;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.*;
 
@@ -156,18 +157,18 @@ public class PolicyEntityBuilder implements EntityBuilder {
     private static String getCDataOrText(Element element) {
         StringBuilder content = new StringBuilder();
         NodeList children = element.getChildNodes();
-        for (int i = 0; i < children.getLength(); i++) {
-            Node child = children.item(i);
+        for (Node child : nodeList(children)) {
             short nodeType = child.getNodeType();
             if (nodeType == Node.TEXT_NODE) {
                 content.append(child.getTextContent());
             } else if (nodeType == Node.CDATA_SECTION_NODE) {
-                return ((CDATASection) child).getData();
+                content.append(((CDATASection) child).getData());
+                break;
             } else {
                 throw new EntityBuilderException("Unexpected set variable assertion expression node type: " + child.getNodeName());
             }
         }
-        return content.toString();
+        return StringEscapeUtils.unescapeXml(content.toString());
     }
 
     @VisibleForTesting

--- a/gateway-export-plugin/build.gradle
+++ b/gateway-export-plugin/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     compile 'com.google.inject:guice:4.2.1'
     compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.9.6'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.6'
+    compile group: 'org.apache.commons', name: 'commons-text', version: '1.6'
 
     testCompile gradleTestKit()
 }

--- a/gateway-export-plugin/build.gradle
+++ b/gateway-export-plugin/build.gradle
@@ -22,7 +22,6 @@ dependencies {
     compile 'com.google.inject:guice:4.2.1'
     compile group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.9.6'
     compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.9.6'
-    compile group: 'org.apache.commons', name: 'commons-text', version: '1.6'
 
     testCompile gradleTestKit()
 }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/SetVariableAssertionSimplifier.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/SetVariableAssertionSimplifier.java
@@ -10,6 +10,7 @@ import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.beans.ContextVariableEnvironmentProperty;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.linker.LinkerException;
+import org.apache.commons.text.StringEscapeUtils;
 import org.w3c.dom.Element;
 
 import javax.inject.Singleton;
@@ -50,7 +51,8 @@ public class SetVariableAssertionSimplifier implements PolicyAssertionSimplifier
             resultantBundle.getEntities(ContextVariableEnvironmentProperty.class).put(contextVarEnvironmentProperty.getName(), contextVarEnvironmentProperty);
         } else {
             Element expressionElement = element.getOwnerDocument().createElement(EXPRESSION);
-            expressionElement.appendChild(element.getOwnerDocument().createCDATASection(new String(decodedValue)));
+            String value = new String(decodedValue);
+            expressionElement.appendChild(element.getOwnerDocument().createCDATASection(StringEscapeUtils.escapeXml11(value)));
             element.insertBefore(expressionElement, base64ExpressionElement);
         }
         element.removeChild(base64ExpressionElement);

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/util/policy/PolicyXMLSimplifierTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/util/policy/PolicyXMLSimplifierTest.java
@@ -100,10 +100,10 @@ class PolicyXMLSimplifierTest {
 
         Element expressionElement = getSingleElement(setVariableAssertion, EXPRESSION);
     assertEquals(
-        "{\n"
-            + "&quot;error&quot;:&quot;invalid_method&quot;,\n"
-            + "&quot;error_description&quot;:&quot;${request.http.method} not permitted&quot;\n"
-            + "}",
+        "{\r\n"
+            + "                &quot;error&quot;:&quot;invalid_method&quot;,\r\n"
+            + "                &quot;error_description&quot;:&quot;${request.http.method} not permitted&quot;\r\n"
+            + "                }",
         expressionElement.getFirstChild().getTextContent());
 
         NodeList base64ElementNodes = setVariableAssertion.getElementsByTagName(BASE_64_EXPRESSION);

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/util/policy/PolicyXMLSimplifierTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/util/policy/PolicyXMLSimplifierTest.java
@@ -111,6 +111,36 @@ class PolicyXMLSimplifierTest {
     }
 
     @Test
+    void simplifySetVariableWithXMLContent() throws DocumentParseException {
+        //The default Base64 decoder in java cannot decode this, but the commons-codec decoder can.
+        Element setVariableAssertion = createSetVariableAssertionElement("userSession", "PHVzZXJzZXNzaW9uPgogPHVzZXI+PCFbQ0RBVEFbJHtjdXJyZW50LnVzZXJuYW1lfV1dPjwvdXNlcj4KIDxyb2xlPjwhW0NEQVRBWyR7Y3VycmVudC51c2VyLnJvbGV9XV0+PC9yb2xlPgogPGxvb2t1cFVzZXI+PCFbQ0RBVEFbJHtsb29rdXBVc2VyfV1dPjwvbG9va3VwVXNlcj4KIDxzeW5jaFRva2VuPjwhW0NEQVRBWyR7eHBhdGhTeW5jaFRva2VuLnJlc3VsdH1dXT48L3N5bmNoVG9rZW4+CjwvdXNlcnNlc3Npb24+");
+        String policyName = "policyName";
+
+        Bundle resultantBundle = new Bundle();
+        new SetVariableAssertionSimplifier()
+                .simplifyAssertionElement(
+                        new PolicySimplifierContext(
+                                policyName,
+                                null,
+                                resultantBundle)
+                                .withAssertionElement(setVariableAssertion)
+                );
+
+        Element expressionElement = getSingleElement(setVariableAssertion, EXPRESSION);
+    assertEquals(
+        "&lt;usersession&gt;\n"
+            + " &lt;user&gt;&lt;![CDATA[${current.username}]]&gt;&lt;/user&gt;\n"
+            + " &lt;role&gt;&lt;![CDATA[${current.user.role}]]&gt;&lt;/role&gt;\n"
+            + " &lt;lookupUser&gt;&lt;![CDATA[${lookupUser}]]&gt;&lt;/lookupUser&gt;\n"
+            + " &lt;synchToken&gt;&lt;![CDATA[${xpathSynchToken.result}]]&gt;&lt;/synchToken&gt;\n"
+            + "&lt;/usersession&gt;",
+        expressionElement.getFirstChild().getTextContent());
+
+        NodeList base64ElementNodes = setVariableAssertion.getElementsByTagName(BASE_64_EXPRESSION);
+        assertEquals(0, base64ElementNodes.getLength());
+    }
+
+    @Test
     void simplifyAuthenticationAssertion() throws DocumentParseException {
         String id = new IdGenerator().generate();
         String testName = "test";

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/util/policy/PolicyXMLSimplifierTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/util/policy/PolicyXMLSimplifierTest.java
@@ -99,10 +99,12 @@ class PolicyXMLSimplifierTest {
                 );
 
         Element expressionElement = getSingleElement(setVariableAssertion, EXPRESSION);
-        assertEquals("{\r\n" +
-                "                \"error\":\"invalid_method\",\r\n" +
-                "                \"error_description\":\"${request.http.method} not permitted\"\r\n" +
-                "                }", expressionElement.getFirstChild().getTextContent());
+    assertEquals(
+        "{\n"
+            + "&quot;error&quot;:&quot;invalid_method&quot;,\n"
+            + "&quot;error_description&quot;:&quot;${request.http.method} not permitted&quot;\n"
+            + "}",
+        expressionElement.getFirstChild().getTextContent());
 
         NodeList base64ElementNodes = setVariableAssertion.getElementsByTagName(BASE_64_EXPRESSION);
         assertEquals(0, base64ElementNodes.getLength());


### PR DESCRIPTION
Fixes #DE414136

## Proposed Changes
* escape chars when exporting to avoid ending with messed xml syntax (when variables have xml content)
* unescaping before build to get the base64 string correctly 
