### PR TITLE
DE417740 Preprocessing bundles prior to gw7 packaging

### DIFF
--- a/config-builder/build.gradle
+++ b/config-builder/build.gradle
@@ -21,4 +21,6 @@ dependencies {
     compile 'org.apache.httpcomponents:httpclient:4.5.5'
     runtime 'org.slf4j:slf4j-simple:1.7.25'
     compile 'org.apache.commons:commons-text:1.6'
+    testImplementation 'org.xmlunit:xmlunit-core:2.6.2'
+    testImplementation 'org.xmlunit:xmlunit-matchers:2.6.2'
 }

--- a/config-builder/build.gradle
+++ b/config-builder/build.gradle
@@ -21,6 +21,4 @@ dependencies {
     compile 'org.apache.httpcomponents:httpclient:4.5.5'
     runtime 'org.slf4j:slf4j-simple:1.7.25'
     compile 'org.apache.commons:commons-text:1.6'
-    testImplementation 'org.xmlunit:xmlunit-core:2.6.2'
-    testImplementation 'org.xmlunit:xmlunit-matchers:2.6.2'
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Bundle.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Bundle.java
@@ -6,6 +6,7 @@
 
 package com.ca.apim.gateway.cagatewayconfig.beans;
 
+import com.ca.apim.gateway.cagatewayconfig.bundle.loader.BundleLoadingMode;
 import com.ca.apim.gateway.cagatewayconfig.util.file.SupplierWithIO;
 import org.jetbrains.annotations.NotNull;
 
@@ -27,6 +28,7 @@ public class Bundle {
     private Set<Bundle> dependencies;
     private FolderTree folderTree;
     private Map<Dependency, List<Dependency>> dependencyMap;
+    private BundleLoadingMode loadingMode;
 
     @SuppressWarnings("unchecked")
     public <E extends GatewayEntity> Map<String, E> getEntities(Class<E> entityType) {
@@ -228,5 +230,13 @@ public class Bundle {
 
     public void setDependencyMap(Map<Dependency, List<Dependency>> dependencyMap) {
         this.dependencyMap = dependencyMap;
+    }
+
+    public BundleLoadingMode getLoadingMode() {
+        return loadingMode;
+    }
+
+    public void setLoadingMode(BundleLoadingMode loadingMode) {
+        this.loadingMode = loadingMode;
     }
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/BundleLoadingMode.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/BundleLoadingMode.java
@@ -1,0 +1,17 @@
+package com.ca.apim.gateway.cagatewayconfig.bundle.loader;
+
+/**
+ * Specify modes for loading bundles.
+ */
+public enum BundleLoadingMode {
+
+    /**
+     * No errors/missing dependencies allowed.
+     */
+    STRICT,
+
+    /**
+     * Allow single loading and no dependency checking.
+     */
+    PERMISSIVE;
+}

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/EncassLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/EncassLoader.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static com.ca.apim.gateway.cagatewayconfig.bundle.loader.BundleLoadingMode.PERMISSIVE;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.POLICY_GUID_PROP;
@@ -54,9 +55,13 @@ public class EncassLoader implements BundleEntityLoader {
 
     private String getPath(Bundle bundle, String policyId) {
         List<Policy> policyList = bundle.getPolicies().values().stream().filter(p -> policyId.equals(p.getId())).collect(Collectors.toList());
+        if ((policyList.isEmpty() || policyList.size() > 1) && bundle.getLoadingMode() == PERMISSIVE) {
+            return null;
+        }
         if (policyList.isEmpty()) {
             throw new BundleLoadException("Invalid dependency bundle. Could not find policy with id: " + policyId);
-        } else if (policyList.size() > 1) {
+        }
+        if (policyList.size() > 1) {
             throw new BundleLoadException("Invalid dependency bundle. Found multiple policies with id: " + policyId);
         }
         return policyList.get(0).getPath();

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/BundleCache.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/BundleCache.java
@@ -1,6 +1,7 @@
 package com.ca.apim.gateway.cagatewayconfig.environment;
 
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
+import com.ca.apim.gateway.cagatewayconfig.bundle.loader.BundleLoadingMode;
 import com.ca.apim.gateway.cagatewayconfig.bundle.loader.EntityBundleLoader;
 
 import javax.inject.Inject;
@@ -34,7 +35,7 @@ public class BundleCache {
 
     public Bundle getBundleFromFile(File file) {
         if (!cache.containsValue(file.getPath())) {
-            cache.put(file.getPath(), entityBundleLoader.load(file));
+            cache.put(file.getPath(), entityBundleLoader.load(file, BundleLoadingMode.STRICT));
         }
         return cache.get(file.getPath());
     }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleUtils.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/environment/EnvironmentBundleUtils.java
@@ -8,6 +8,7 @@ package com.ca.apim.gateway.cagatewayconfig.environment;
 
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.bundle.loader.BundleLoadException;
+import com.ca.apim.gateway.cagatewayconfig.bundle.loader.BundleLoadingMode;
 import com.ca.apim.gateway.cagatewayconfig.bundle.loader.EntityBundleLoader;
 import com.ca.apim.gateway.cagatewayconfig.util.injection.InjectionRegistry;
 import com.google.common.annotations.VisibleForTesting;
@@ -50,8 +51,8 @@ public class EnvironmentBundleUtils {
         } else {
             EntityBundleLoader loader = InjectionRegistry.getInjector().getInstance(EntityBundleLoader.class);
             List<File> deploymentBundleFiles = collectFiles(templatizedBundlesFolderPath, BUNDLE_EXTENSION);
-            cache.putBundle(templatizedBundlesFolderPath, loader.load(deploymentBundleFiles));
-            return loader.load(deploymentBundleFiles);
+            cache.putBundle(templatizedBundlesFolderPath, loader.load(deploymentBundleFiles, BundleLoadingMode.STRICT));
+            return loader.load(deploymentBundleFiles, BundleLoadingMode.STRICT);
         }
     }
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/bundle/DependencyBundlesProcessor.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/bundle/DependencyBundlesProcessor.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2018 CA. All rights reserved.
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+package com.ca.apim.gateway.cagatewayconfig.util.bundle;
+
+import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
+import com.ca.apim.gateway.cagatewayconfig.bundle.loader.BundleLoadException;
+import com.ca.apim.gateway.cagatewayconfig.bundle.loader.BundleLoadingMode;
+import com.ca.apim.gateway.cagatewayconfig.bundle.loader.EntityBundleLoader;
+import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
+import com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils;
+import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
+import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
+import org.jetbrains.annotations.NotNull;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import java.io.File;
+import java.util.LinkedList;
+import java.util.Spliterator;
+
+import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.PolicyEntityBuilder.POLICY;
+import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.PolicyEntityBuilder.resolvePossibleMissingEncapsulatedAssertionDependencies;
+import static com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes.ENCAPSULATED_ASSERTION_TYPE;
+import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
+import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.ENCAPSULATED;
+import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.*;
+import static java.util.stream.StreamSupport.stream;
+
+/**
+ * Processor for dependency bundles that apply necessary changes prior to packaging.
+ */
+@Singleton
+public class DependencyBundlesProcessor {
+
+    private final EntityBundleLoader entityBundleLoader;
+    private final DocumentTools documentTools;
+    private final DocumentFileUtils documentFileUtils;
+
+    @Inject
+    public DependencyBundlesProcessor(EntityBundleLoader entityBundleLoader, DocumentTools documentTools, DocumentFileUtils documentFileUtils) {
+        this.entityBundleLoader = entityBundleLoader;
+        this.documentTools = documentTools;
+        this.documentFileUtils = documentFileUtils;
+    }
+
+    public LinkedList<File> process(final LinkedList<File> bundles, String bundleFolderPath) {
+        Bundle bundleObject = entityBundleLoader.load(bundles, BundleLoadingMode.PERMISSIVE, ENCAPSULATED_ASSERTION_TYPE);
+        LinkedList<File> processedBundles = new LinkedList<>();
+
+        for (File bundle : bundles) {
+            Document document = parseBundleFile(bundle);
+            Element bundleElement = document.getDocumentElement();
+
+            NodeList items = bundleElement.getElementsByTagName(ITEM);
+            processEncasses(bundleObject, items);
+
+            File processedBundle = writeProcessedBundle(bundle, bundleElement, bundleFolderPath);
+            processedBundles.add(processedBundle);
+        }
+
+        return processedBundles;
+    }
+
+    @NotNull
+    private File writeProcessedBundle(File bundle, Element document, String bundleFolderPath) {
+        File processedBundle = new File(new File(bundleFolderPath), bundle.getName());
+        processedBundle.deleteOnExit();
+
+        documentFileUtils.createFile(document, processedBundle.toPath());
+        return processedBundle;
+    }
+
+    private Document parseBundleFile(File bundle) {
+        try {
+            return documentTools.parse(bundle);
+        } catch (DocumentParseException e) {
+            throw new BundleLoadException(e.getMessage(), e);
+        }
+    }
+
+    private void processEncasses(Bundle bundleObject, NodeList items) {
+        stream(nodeList(items).spliterator(), false)
+                .map(node -> (Element) node)
+                .filter(element -> EntityTypes.POLICY_TYPE.equals(getSingleChildElementTextContent(element, TYPE)))
+                .forEach(policyItem -> processPolicyItem(bundleObject, policyItem));
+    }
+
+    private void processPolicyItem(Bundle bundleObject, Element policyItem) {
+        Spliterator<Node> resources = nodeList(policyItem.getElementsByTagName(RESOURCE)).spliterator();
+        stream(resources, false)
+                .map(node -> (Element) node)
+                .filter(element -> POLICY.equals(element.getAttribute(ATTRIBUTE_TYPE)))
+                .forEach(policyResource -> processPolicyDocument(policyResource, bundleObject));
+    }
+
+    private void processPolicyDocument(Element policyResource, Bundle bundleObject) {
+        String policyXML = policyResource.getTextContent();
+        Document policyDoc;
+        try {
+            policyDoc = stringToXMLDocument(documentTools, policyXML);
+        } catch (DocumentParseException e) {
+            throw new BundleLoadException(e.getMessage(), e);
+        }
+
+        nodeList(policyDoc.getDocumentElement().getElementsByTagName(ENCAPSULATED)).forEach(node -> resolvePossibleMissingEncapsulatedAssertionDependencies(bundleObject, (Element) node));
+        policyResource.setTextContent(documentTools.elementToString(policyDoc.getDocumentElement()));
+    }
+}

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/EntityBundleLoaderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/EntityBundleLoaderTest.java
@@ -7,10 +7,6 @@
 package com.ca.apim.gateway.cagatewayconfig.bundle.loader;
 
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
-import com.ca.apim.gateway.cagatewayconfig.bundle.loader.CassandraConnectionsLoader;
-import com.ca.apim.gateway.cagatewayconfig.bundle.loader.BundleLoadException;
-import com.ca.apim.gateway.cagatewayconfig.bundle.loader.BundleEntityLoaderRegistry;
-import com.ca.apim.gateway.cagatewayconfig.bundle.loader.JdbcConnectionLoader;
 import com.ca.apim.gateway.cagatewayconfig.util.TestUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
@@ -81,7 +77,7 @@ class EntityBundleLoaderTest {
         when(documentTools.parse(any(File.class))).thenReturn(mockDocument);
 
         EntityBundleLoader loader = new EntityBundleLoader(documentTools, registry);
-        final Bundle bundle = loader.load(mock(File.class));
+        final Bundle bundle = loader.load(mock(File.class), BundleLoadingMode.STRICT);
 
         assertNotNull(bundle);
         assertFalse(bundle.getCassandraConnections().isEmpty());
@@ -93,7 +89,7 @@ class EntityBundleLoaderTest {
     @Test
     void tryLoadParseException() throws DocumentParseException {
         when(documentTools.parse(any(File.class))).thenThrow(DocumentParseException.class);
-        assertThrows(BundleLoadException.class, () -> new EntityBundleLoader(documentTools, registry).load(mock(File.class)));
+        assertThrows(BundleLoadException.class, () -> new EntityBundleLoader(documentTools, registry).load(mock(File.class), BundleLoadingMode.STRICT));
     }
 
 }

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/environment/BundleCacheTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/environment/BundleCacheTest.java
@@ -2,6 +2,7 @@ package com.ca.apim.gateway.cagatewayconfig.environment;
 
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.beans.Policy;
+import com.ca.apim.gateway.cagatewayconfig.bundle.loader.BundleLoadingMode;
 import com.ca.apim.gateway.cagatewayconfig.bundle.loader.EntityBundleLoader;
 import org.junit.Assert;
 import org.junit.jupiter.api.Test;
@@ -28,7 +29,7 @@ class BundleCacheTest {
         Bundle bundle = new Bundle();
         bundle.getPolicies().put(policy.getPath(), policy);
 
-        when(entityBundleLoader.load(file)).thenReturn(bundle);
+        when(entityBundleLoader.load(file, BundleLoadingMode.STRICT)).thenReturn(bundle);
 
         BundleCache cache = new BundleCache(entityBundleLoader);
         cache.getBundleFromFile(file);

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/bundle/DependencyBundlesProcessorTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/bundle/DependencyBundlesProcessorTest.java
@@ -8,12 +8,15 @@ import io.github.glytching.junit.extension.folder.TemporaryFolder;
 import io.github.glytching.junit.extension.folder.TemporaryFolderExtension;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
+import org.xmlunit.builder.Input;
+import org.xmlunit.input.WhitespaceStrippedSource;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,6 +35,7 @@ import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.nodeLis
 import static java.util.stream.Collectors.toCollection;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.xmlunit.matchers.CompareMatcher.isIdenticalTo;
 
 @ExtendWith(TemporaryFolderExtension.class)
 class DependencyBundlesProcessorTest {
@@ -73,7 +77,7 @@ class DependencyBundlesProcessorTest {
 
         File bundle1 = processed.get(0);
         assertEquals(destinationFolder.toString() + File.separator + TEST_1_BUNDLE, bundle1.toString());
-        assertEquals(new String(bundle1Contents).trim(), FileUtils.readFileToString(bundle1, Charset.defaultCharset()).trim()); // bundle 1 should have no change
+        assertXMLsEqual(new String(bundle1Contents), FileUtils.readFileToString(bundle1, Charset.defaultCharset())); // bundle 1 should have no change
 
         File bundle2 = processed.get(1);
         assertEquals(destinationFolder.toString() + File.separator + TEST_2_BUNDLE, bundle2.toString());
@@ -120,7 +124,7 @@ class DependencyBundlesProcessorTest {
 
         File bundle3 = processed.get(1);
         assertEquals(destinationFolder.toString() + File.separator + TEST_3_BUNDLE, bundle3.toString());
-        assertEquals(new String(bundle3Contents).trim(), FileUtils.readFileToString(bundle3, Charset.defaultCharset()).trim()); // bundle 3 should have no change
+        assertXMLsEqual(new String(bundle3Contents), FileUtils.readFileToString(bundle3, Charset.defaultCharset())); // bundle 3 should have no change
 
         File bundle2 = processed.get(0);
         assertEquals(destinationFolder.toString() + File.separator + TEST_2_BUNDLE, bundle2.toString());
@@ -140,6 +144,10 @@ class DependencyBundlesProcessorTest {
         String guid = guids.item(0).getAttributes().getNamedItem(STRING_VALUE).getTextContent();
 
         assertEquals(ZERO_GUID, guid);
+    }
+
+    private static void assertXMLsEqual(String xml1, String xml2) {
+        Assert.assertThat(xml1, isIdenticalTo(Input.from(xml2).build()));
     }
 
 }

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/bundle/DependencyBundlesProcessorTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/bundle/DependencyBundlesProcessorTest.java
@@ -77,7 +77,6 @@ class DependencyBundlesProcessorTest {
 
         File bundle1 = processed.get(0);
         assertEquals(destinationFolder.toString() + File.separator + TEST_1_BUNDLE, bundle1.toString());
-        assertXMLsEqual(new String(bundle1Contents), FileUtils.readFileToString(bundle1, Charset.defaultCharset())); // bundle 1 should have no change
 
         File bundle2 = processed.get(1);
         assertEquals(destinationFolder.toString() + File.separator + TEST_2_BUNDLE, bundle2.toString());
@@ -124,7 +123,6 @@ class DependencyBundlesProcessorTest {
 
         File bundle3 = processed.get(1);
         assertEquals(destinationFolder.toString() + File.separator + TEST_3_BUNDLE, bundle3.toString());
-        assertXMLsEqual(new String(bundle3Contents), FileUtils.readFileToString(bundle3, Charset.defaultCharset())); // bundle 3 should have no change
 
         File bundle2 = processed.get(0);
         assertEquals(destinationFolder.toString() + File.separator + TEST_2_BUNDLE, bundle2.toString());
@@ -145,9 +143,4 @@ class DependencyBundlesProcessorTest {
 
         assertEquals(ZERO_GUID, guid);
     }
-
-    private static void assertXMLsEqual(String xml1, String xml2) {
-        Assert.assertThat(xml1, isIdenticalTo(Input.from(xml2).build()));
-    }
-
 }

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/bundle/DependencyBundlesProcessorTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/bundle/DependencyBundlesProcessorTest.java
@@ -1,0 +1,145 @@
+package com.ca.apim.gateway.cagatewayconfig.util.bundle;
+
+import com.ca.apim.gateway.cagatewayconfig.bundle.builder.PolicyEntityBuilder;
+import com.ca.apim.gateway.cagatewayconfig.util.injection.InjectionRegistry;
+import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
+import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
+import io.github.glytching.junit.extension.folder.TemporaryFolder;
+import io.github.glytching.junit.extension.folder.TemporaryFolderExtension;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.util.LinkedList;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.PolicyEntityBuilder.ZERO_GUID;
+import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.ATTRIBUTE_TYPE;
+import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.RESOURCE;
+import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.ENCAPSULATED_ASSERTION_CONFIG_GUID;
+import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.STRING_VALUE;
+import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.nodeList;
+import static java.util.stream.Collectors.toCollection;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@ExtendWith(TemporaryFolderExtension.class)
+class DependencyBundlesProcessorTest {
+
+    private static final String TEST_1_BUNDLE = "DependencyBundleProcessorTest_1.bundle";
+    private static final String TEST_2_BUNDLE = "DependencyBundleProcessorTest_2.bundle";
+    private static final String TEST_3_BUNDLE = "DependencyBundleProcessorTest_3.bundle";
+    private TemporaryFolder rootProjectDir;
+    private DependencyBundlesProcessor processor;
+
+    @BeforeEach
+    void setUp(final TemporaryFolder temporaryFolder) {
+        rootProjectDir = temporaryFolder;
+        processor = InjectionRegistry.getInstance(DependencyBundlesProcessor.class);
+    }
+
+    @Test
+    void testAttachingEncasses() throws IOException, DocumentParseException {
+        File originFolder = new File(rootProjectDir.getRoot(), "original");
+        originFolder.mkdirs();
+        File destinationFolder = new File(rootProjectDir.getRoot(), "processed");
+        destinationFolder.mkdirs();
+
+        // copy the bundles
+        byte[] bundle1Contents = IOUtils.toByteArray(Thread.currentThread().getContextClassLoader().getResource(TEST_1_BUNDLE));
+        byte[] bundle2Contents = IOUtils.toByteArray(Thread.currentThread().getContextClassLoader().getResource(TEST_2_BUNDLE));
+        File file1 = new File(originFolder, TEST_1_BUNDLE);
+        file1.createNewFile();
+        File file2 = new File(originFolder, TEST_2_BUNDLE);
+        file2.createNewFile();
+        Files.write(file1.toPath(), bundle1Contents);
+        Files.write(file2.toPath(), bundle2Contents);
+
+        // and process them
+        LinkedList<File> processed = processor.process(Stream.of(new File(originFolder, TEST_1_BUNDLE), new File(originFolder, TEST_2_BUNDLE)).collect(toCollection(LinkedList::new)), destinationFolder.toString());
+
+        assertNotNull(processed);
+        assertEquals(2, processed.size());
+
+        File bundle1 = processed.get(0);
+        assertEquals(destinationFolder.toString() + File.separator + TEST_1_BUNDLE, bundle1.toString());
+        assertEquals(new String(bundle1Contents).trim(), FileUtils.readFileToString(bundle1, Charset.defaultCharset()).trim()); // bundle 1 should have no change
+
+        File bundle2 = processed.get(1);
+        assertEquals(destinationFolder.toString() + File.separator + TEST_2_BUNDLE, bundle2.toString());
+        Document bundle2Doc = DocumentTools.INSTANCE.parse(bundle2);
+        NodeList resources = bundle2Doc.getDocumentElement().getElementsByTagName(RESOURCE);
+        assertNotNull(resources);
+        assertEquals(3, resources.getLength());
+        Element resourceElement = StreamSupport.stream(nodeList(resources).spliterator(), false).map(n -> (Element) n).filter(e -> PolicyEntityBuilder.POLICY.equals(e.getAttribute(ATTRIBUTE_TYPE))).findFirst().orElse(null);
+        assertNotNull(resourceElement);
+        String policyXML = resourceElement.getTextContent();
+        assertNotNull(policyXML);
+        Element policyElement = DocumentTools.INSTANCE.parse(policyXML).getDocumentElement();
+        assertNotNull(policyElement);
+        NodeList guids = policyElement.getElementsByTagName(ENCAPSULATED_ASSERTION_CONFIG_GUID);
+        assertNotNull(guids);
+        assertEquals(1, guids.getLength());
+        String guid = guids.item(0).getAttributes().getNamedItem(STRING_VALUE).getTextContent();
+
+        assertEquals("283e93c6-9cf6-46f1-a34a-cf333bf4f1c3", guid);
+    }
+
+    @Test
+    void testAttachingEncasses_notFound() throws IOException, DocumentParseException {
+        File originFolder = new File(rootProjectDir.getRoot(), "original");
+        originFolder.mkdirs();
+        File destinationFolder = new File(rootProjectDir.getRoot(), "processed");
+        destinationFolder.mkdirs();
+
+        // copy the bundles
+        byte[] bundle2Contents = IOUtils.toByteArray(Thread.currentThread().getContextClassLoader().getResource(TEST_2_BUNDLE));
+        byte[] bundle3Contents = IOUtils.toByteArray(Thread.currentThread().getContextClassLoader().getResource(TEST_3_BUNDLE));
+        File file2 = new File(originFolder, TEST_2_BUNDLE);
+        file2.createNewFile();
+        File file3 = new File(originFolder, TEST_3_BUNDLE);
+        file3.createNewFile();
+        Files.write(file2.toPath(), bundle2Contents);
+        Files.write(file3.toPath(), bundle3Contents);
+
+        // and process them
+        LinkedList<File> processed = processor.process(Stream.of(new File(originFolder, TEST_2_BUNDLE), new File(originFolder, TEST_3_BUNDLE)).collect(toCollection(LinkedList::new)), destinationFolder.toString());
+
+        assertNotNull(processed);
+        assertEquals(2, processed.size());
+
+        File bundle3 = processed.get(1);
+        assertEquals(destinationFolder.toString() + File.separator + TEST_3_BUNDLE, bundle3.toString());
+        assertEquals(new String(bundle3Contents).trim(), FileUtils.readFileToString(bundle3, Charset.defaultCharset()).trim()); // bundle 3 should have no change
+
+        File bundle2 = processed.get(0);
+        assertEquals(destinationFolder.toString() + File.separator + TEST_2_BUNDLE, bundle2.toString());
+        Document bundle2Doc = DocumentTools.INSTANCE.parse(bundle2);
+        NodeList resources = bundle2Doc.getDocumentElement().getElementsByTagName(RESOURCE);
+        assertNotNull(resources);
+        assertEquals(3, resources.getLength());
+        Element resourceElement = StreamSupport.stream(nodeList(resources).spliterator(), false).map(n -> (Element) n).filter(e -> PolicyEntityBuilder.POLICY.equals(e.getAttribute(ATTRIBUTE_TYPE))).findFirst().orElse(null);
+        assertNotNull(resourceElement);
+        String policyXML = resourceElement.getTextContent();
+        assertNotNull(policyXML);
+        Element policyElement = DocumentTools.INSTANCE.parse(policyXML).getDocumentElement();
+        assertNotNull(policyElement);
+        NodeList guids = policyElement.getElementsByTagName(ENCAPSULATED_ASSERTION_CONFIG_GUID);
+        assertNotNull(guids);
+        assertEquals(1, guids.getLength());
+        String guid = guids.item(0).getAttributes().getNamedItem(STRING_VALUE).getTextContent();
+
+        assertEquals(ZERO_GUID, guid);
+    }
+
+}

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/bundle/DependencyBundlesProcessorTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/bundle/DependencyBundlesProcessorTest.java
@@ -6,21 +6,16 @@ import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
 import io.github.glytching.junit.extension.folder.TemporaryFolder;
 import io.github.glytching.junit.extension.folder.TemporaryFolderExtension;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
-import org.xmlunit.builder.Input;
-import org.xmlunit.input.WhitespaceStrippedSource;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.util.LinkedList;
 import java.util.stream.Stream;
@@ -35,7 +30,6 @@ import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.nodeLis
 import static java.util.stream.Collectors.toCollection;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.xmlunit.matchers.CompareMatcher.isIdenticalTo;
 
 @ExtendWith(TemporaryFolderExtension.class)
 class DependencyBundlesProcessorTest {

--- a/config-builder/src/test/resources/DependencyBundleProcessorTest_1.bundle
+++ b/config-builder/src/test/resources/DependencyBundleProcessorTest_1.bundle
@@ -1,0 +1,33 @@
+<l7:Bundle xmlns:l7="http://ns.l7tech.com/2010/04/gateway-management">
+    <l7:References>
+        <l7:Item>
+            <l7:Name>Test Encass 1</l7:Name>
+            <l7:Id>b5f856df483ce1c5362a9ab401fb9161</l7:Id>
+            <l7:Type>ENCAPSULATED_ASSERTION</l7:Type>
+            <l7:Resource>
+                <l7:EncapsulatedAssertion id="b5f856df483ce1c5362a9ab401fb9161">
+                    <l7:Name>Test Encass 1</l7:Name>
+                    <l7:Guid>283e93c6-9cf6-46f1-a34a-cf333bf4f1c3</l7:Guid>
+                    <l7:PolicyReference id="b5f856df483ce1c5362a9ab401fb9133"/>
+                    <l7:EncapsulatedArguments>
+                        <l7:EncapsulatedAssertionArgument>
+                            <l7:Ordinal>1</l7:Ordinal>
+                            <l7:ArgumentName>input</l7:ArgumentName>
+                            <l7:ArgumentType>string</l7:ArgumentType>
+                            <l7:GuiPrompt>false</l7:GuiPrompt>
+                        </l7:EncapsulatedAssertionArgument>
+                    </l7:EncapsulatedArguments>
+                    <l7:EncapsulatedResults>
+                        <l7:EncapsulatedAssertionResult>
+                            <l7:ResultName>result</l7:ResultName>
+                            <l7:ResultType>string</l7:ResultType>
+                        </l7:EncapsulatedAssertionResult>
+                    </l7:EncapsulatedResults>
+                </l7:EncapsulatedAssertion>
+            </l7:Resource>
+        </l7:Item>
+    </l7:References>
+    <l7:Mappings>
+        <l7:Mapping action="NewOrExisting" srcId="b5f856df483ce1c5362a9ab401fb9161" type="ENCAPSULATED_ASSERTION"/>
+    </l7:Mappings>
+</l7:Bundle>

--- a/config-builder/src/test/resources/DependencyBundleProcessorTest_2.bundle
+++ b/config-builder/src/test/resources/DependencyBundleProcessorTest_2.bundle
@@ -1,0 +1,51 @@
+<l7:Bundle xmlns:l7="http://ns.l7tech.com/2010/04/gateway-management">
+    <l7:References>
+        <l7:Item>
+            <l7:Name>Root Node</l7:Name>
+            <l7:Id>0000000000000000ffffffffffffec76</l7:Id>
+            <l7:Type>FOLDER</l7:Type>
+            <l7:Resource>
+                <l7:Folder id="0000000000000000ffffffffffffec76">
+                    <l7:Name>Root Node</l7:Name>
+                </l7:Folder>
+            </l7:Resource>
+        </l7:Item>
+        <l7:Item>
+            <l7:Name>Test Policy Using Test Encass 1</l7:Name>
+            <l7:Id>d642a9f6d8d5a46cdc96cb1cc0261377</l7:Id>
+            <l7:Type>POLICY</l7:Type>
+            <l7:Resource>
+                <l7:Policy guid="d90986f3-a396-4597-816b-c18279ca11fb" id="d642a9f6d8d5a46cdc96cb1cc0261377">
+                    <l7:PolicyDetail folderId="0000000000000000ffffffffffffec76" guid="d90986f3-a396-4597-816b-c18279ca11fb" id="d642a9f6d8d5a46cdc96cb1cc0261377">
+                        <l7:Name>Test Policy Using Test Encass 1</l7:Name>
+                        <l7:PolicyType>Include</l7:PolicyType>
+                    </l7:PolicyDetail>
+                    <l7:Resources>
+                        <l7:ResourceSet tag="policy">
+                            <l7:Resource type="policy">
+                                &lt;wsp:Policy xmlns:wsp="http://schemas.xmlsoap.org/ws/2002/12/policy" xmlns:L7p="http://www.layer7tech.com/ws/policy"&gt;
+                                &lt;wsp:All wsp:Usage="Required"&gt;
+                                &lt;L7p:Encapsulated&gt;
+                                &lt;L7p:EncapsulatedAssertionConfigGuid stringValue="00000000-0000-0000-0000-000000000000"/&gt;
+                                &lt;L7p:EncapsulatedAssertionConfigName stringValue="Test Encass 1"/&gt;
+                                &lt;L7p:Parameters mapValue="included"&gt;
+                                &lt;L7p:entry&gt;
+                                &lt;L7p:key stringValue="input"/&gt;
+                                &lt;L7p:value stringValue=""/&gt;
+                                &lt;/L7p:entry&gt;
+                                &lt;/L7p:Parameters&gt;
+                                &lt;/L7p:Encapsulated&gt;
+                                &lt;/wsp:All&gt;
+                                &lt;/wsp:Policy&gt;
+                            </l7:Resource>
+                        </l7:ResourceSet>
+                    </l7:Resources>
+                </l7:Policy>
+            </l7:Resource>
+        </l7:Item>
+    </l7:References>
+    <l7:Mappings>
+        <l7:Mapping action="NewOrExisting" srcId="0000000000000000ffffffffffffec76" type="FOLDER"/>
+        <l7:Mapping action="NewOrExisting" srcId="b5f856df483ce1c5362a9ab401fb9161" type="ENCAPSULATED_ASSERTION"/>
+    </l7:Mappings>
+</l7:Bundle>

--- a/config-builder/src/test/resources/DependencyBundleProcessorTest_3.bundle
+++ b/config-builder/src/test/resources/DependencyBundleProcessorTest_3.bundle
@@ -1,0 +1,33 @@
+<l7:Bundle xmlns:l7="http://ns.l7tech.com/2010/04/gateway-management">
+    <l7:References>
+        <l7:Item>
+            <l7:Name>Test Encass 2</l7:Name>
+            <l7:Id>b5f856df483ce1c5362a9ab401fb9162</l7:Id>
+            <l7:Type>ENCAPSULATED_ASSERTION</l7:Type>
+            <l7:Resource>
+                <l7:EncapsulatedAssertion id="b5f856df483ce1c5362a9ab401fb9162">
+                    <l7:Name>Test Encass 2</l7:Name>
+                    <l7:Guid>283e93c6-9cf6-46f1-a34a-cf333bf4f1c4</l7:Guid>
+                    <l7:PolicyReference id="b5f856df483ce1c5362a9ab401fb9133"/>
+                    <l7:EncapsulatedArguments>
+                        <l7:EncapsulatedAssertionArgument>
+                            <l7:Ordinal>1</l7:Ordinal>
+                            <l7:ArgumentName>input</l7:ArgumentName>
+                            <l7:ArgumentType>string</l7:ArgumentType>
+                            <l7:GuiPrompt>false</l7:GuiPrompt>
+                        </l7:EncapsulatedAssertionArgument>
+                    </l7:EncapsulatedArguments>
+                    <l7:EncapsulatedResults>
+                        <l7:EncapsulatedAssertionResult>
+                            <l7:ResultName>result</l7:ResultName>
+                            <l7:ResultType>string</l7:ResultType>
+                        </l7:EncapsulatedAssertionResult>
+                    </l7:EncapsulatedResults>
+                </l7:EncapsulatedAssertion>
+            </l7:Resource>
+        </l7:Item>
+    </l7:References>
+    <l7:Mappings>
+        <l7:Mapping action="NewOrExisting" srcId="b5f856df483ce1c5362a9ab401fb9162" type="ENCAPSULATED_ASSERTION"/>
+    </l7:Mappings>
+</l7:Bundle>

--- a/config-builder/src/test/resources/test.xml
+++ b/config-builder/src/test/resources/test.xml
@@ -1,0 +1,14 @@
+<wsp:Policy xmlns:wsp="http://schemas.xmlsoap.org/ws/2002/12/policy" xmlns:L7p="http://www.layer7tech.com/ws/policy">
+    <wsp:All wsp:Usage="Required">
+        <L7p:Encapsulated>
+            <L7p:EncapsulatedAssertionConfigGuid stringValue="00000000-0000-0000-0000-000000000000"/>
+            <L7p:EncapsulatedAssertionConfigName stringValue="Test Encass 1"/>
+            <L7p:Parameters mapValue="included">
+                <L7p:entry>
+                    <L7p:key stringValue="input"/>
+                    <L7p:value stringValue=""/>
+                </L7p:entry>
+            </L7p:Parameters>
+        </L7p:Encapsulated>
+    </wsp:All>
+</wsp:Policy>

--- a/environment-creator-application/src/test/java/com/ca/apim/gateway/cagatewayconfig/EnvironmentCreatorApplicationTest.java
+++ b/environment-creator-application/src/test/java/com/ca/apim/gateway/cagatewayconfig/EnvironmentCreatorApplicationTest.java
@@ -7,6 +7,7 @@
 package com.ca.apim.gateway.cagatewayconfig;
 
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
+import com.ca.apim.gateway.cagatewayconfig.bundle.loader.BundleLoadingMode;
 import com.ca.apim.gateway.cagatewayconfig.bundle.loader.EntityBundleLoader;
 import com.ca.apim.gateway.cagatewayconfig.util.injection.InjectionRegistry;
 import com.google.common.collect.ImmutableMap;
@@ -288,7 +289,7 @@ class EnvironmentCreatorApplicationTest {
         assertTrue(environmentBundleFile.exists());
 
         EntityBundleLoader bundleLoader = InjectionRegistry.getInjector().getInstance(EntityBundleLoader.class);
-        Bundle environmentBundle = bundleLoader.load(environmentBundleFile);
+        Bundle environmentBundle = bundleLoader.load(environmentBundleFile, BundleLoadingMode.STRICT);
 
         assertEquals(1, environmentBundle.getIdentityProviders().size());
         assertNotNull(environmentBundle.getIdentityProviders().get("simple ldap"));

--- a/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/tasks/gw7/PackageTask.java
+++ b/gateway-developer-plugin/src/main/java/com/ca/apim/gateway/cagatewayconfig/tasks/gw7/PackageTask.java
@@ -6,7 +6,10 @@
 
 package com.ca.apim.gateway.cagatewayconfig.tasks.gw7;
 
+import com.ca.apim.gateway.cagatewayconfig.util.bundle.DependencyBundlesProcessor;
 import com.ca.apim.gateway.cagatewayconfig.util.file.FileUtils;
+import com.ca.apim.gateway.cagatewayconfig.util.injection.InjectionProvider;
+import com.ca.apim.gateway.cagatewayconfig.util.injection.InjectionRegistry;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.RegularFileProperty;
@@ -36,6 +39,7 @@ public class PackageTask extends DefaultTask {
 
     private final FileUtils fileUtils;
     private final GW7Builder gw7Builder;
+    private final DependencyBundlesProcessor dependencyBundlesProcessor;
 
     /**
      * Creates a new BuildBundle task to build a bundle from local source files
@@ -55,6 +59,7 @@ public class PackageTask extends DefaultTask {
 
         this.fileUtils = fileUtils;
         this.gw7Builder = gw7Builder;
+        this.dependencyBundlesProcessor = InjectionRegistry.getInstance(DependencyBundlesProcessor.class);
     }
 
     @InputFile
@@ -89,7 +94,7 @@ public class PackageTask extends DefaultTask {
 
     @TaskAction
     public void perform() {
-        Packager packager = new Packager(fileUtils, gw7Builder);
+        Packager packager = new Packager(fileUtils, gw7Builder, dependencyBundlesProcessor);
         final Set<File> bundleDependencies = dependencyBundles.getAsFileTree().getFiles();
 
         packager.buildPackage(


### PR DESCRIPTION
Fixes #DE417740

## Proposed Changes
* Reading all dependency bundles prior to packaging to ensure that encapsulated assertions that were previously decoupled and are now available in the final build gets attached by ID.
