### PR TITLE
TA1279175 Allowing environment vars without specifying content type

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/environment/EnvironmentConfigurationUtils.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/environment/EnvironmentConfigurationUtils.java
@@ -11,6 +11,7 @@ import com.ca.apim.gateway.cagatewayconfig.config.loader.EntityLoaderRegistry;
 import com.ca.apim.gateway.cagatewayconfig.environment.MissingEnvironmentException;
 import com.ca.apim.gateway.cagatewayconfig.util.json.JsonTools;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.inject.Inject;
@@ -22,9 +23,11 @@ import java.util.Map.Entry;
 import java.util.function.Consumer;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.json.JsonTools.JSON;
+import static com.ca.apim.gateway.cagatewayconfig.util.json.JsonTools.YAML;
 import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.PREFIX_ENV;
 import static java.util.Collections.unmodifiableMap;
 import static java.util.Optional.ofNullable;
+import static org.apache.commons.lang3.StringUtils.isBlank;
 
 /**
  * Utility class to handle tasks related to environment properties
@@ -89,6 +92,21 @@ public class EnvironmentConfigurationUtils {
             return jsonTools.getObjectWriter(JSON).writeValueAsString(entity);
         } catch (JsonProcessingException e) {
             throw new MissingEnvironmentException("Unable to read environment for specified configuration " + entityName, e);
+        }
+    }
+
+    public static String tryInferContentTypeFromValue(final String value) {
+        if (isBlank(value)) {
+            return null;
+        }
+
+        // remove extra spaces and pick first char
+        char initial = value.trim().charAt(0);
+        switch (initial) {
+            case '[':
+            case '{': return JSON;
+            case '<': throw new MissingEnvironmentException("XML Environment Values are not yet supported.");
+            default: return YAML;
         }
     }
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/environment/EnvironmentConfigurationUtils.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/environment/EnvironmentConfigurationUtils.java
@@ -11,7 +11,6 @@ import com.ca.apim.gateway.cagatewayconfig.config.loader.EntityLoaderRegistry;
 import com.ca.apim.gateway.cagatewayconfig.environment.MissingEnvironmentException;
 import com.ca.apim.gateway.cagatewayconfig.util.json.JsonTools;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 
 import javax.inject.Inject;

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/environment/EnvironmentConfigurationUtilsTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/environment/EnvironmentConfigurationUtilsTest.java
@@ -1,0 +1,32 @@
+package com.ca.apim.gateway.cagatewayconfig.util.environment;
+
+import com.ca.apim.gateway.cagatewayconfig.environment.MissingEnvironmentException;
+import com.ca.apim.gateway.cagatewayconfig.util.json.JsonTools;
+import org.junit.jupiter.api.Test;
+
+import static com.ca.apim.gateway.cagatewayconfig.util.environment.EnvironmentConfigurationUtils.tryInferContentTypeFromValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class EnvironmentConfigurationUtilsTest {
+
+    @Test
+    void inferContentYaml() {
+        assertEquals(JsonTools.YAML, tryInferContentTypeFromValue("test1:1\ntest1:2"));
+    }
+
+    @Test
+    void inferContentJson() {
+        assertEquals(JsonTools.JSON, tryInferContentTypeFromValue("{ 'test1': 1, 'test2': 2 }"));
+    }
+
+    @Test
+    void inferContentJsonArray() {
+        assertEquals(JsonTools.JSON, tryInferContentTypeFromValue("[ { 'test1': 1, 'test2': 2 }, { 'test3': 3, 'test4': 4 } ]"));
+    }
+
+    @Test
+    void inferContentXMLUnsupported() {
+        assertThrows(MissingEnvironmentException.class, () -> tryInferContentTypeFromValue("<test1>1</test1><test2>2</test2>"));
+    }
+}


### PR DESCRIPTION
Fixes #TA1279175

## Proposed Changes
* Allowing environment vars without specifying content type by inferring type from the content.
