### PR TITLE
DE419734 Preprocessing bundles prior to gw7 packaging - now for service policies

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/bundle/DependencyBundlesProcessor.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/bundle/DependencyBundlesProcessor.java
@@ -14,7 +14,6 @@ import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
-import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/bundle/DependencyBundlesProcessor.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/bundle/DependencyBundlesProcessor.java
@@ -14,6 +14,7 @@ import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import com.ca.apim.gateway.cagatewayconfig.util.file.DocumentFileUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
+import org.apache.commons.lang3.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -33,6 +34,7 @@ import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementName
 import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.ENCAPSULATED;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.*;
 import static java.util.stream.StreamSupport.stream;
+import static org.apache.commons.lang3.StringUtils.equalsAny;
 
 /**
  * Processor for dependency bundles that apply necessary changes prior to packaging.
@@ -89,7 +91,7 @@ public class DependencyBundlesProcessor {
     private void processEncasses(Bundle bundleObject, NodeList items) {
         stream(nodeList(items).spliterator(), false)
                 .map(node -> (Element) node)
-                .filter(element -> EntityTypes.POLICY_TYPE.equals(getSingleChildElementTextContent(element, TYPE)))
+                .filter(element -> equalsAny(getSingleChildElementTextContent(element, TYPE), EntityTypes.POLICY_TYPE, EntityTypes.SERVICE_TYPE))
                 .forEach(policyItem -> processPolicyItem(bundleObject, policyItem));
     }
 

--- a/config-builder/src/test/resources/DependencyBundleProcessorTest_4.bundle
+++ b/config-builder/src/test/resources/DependencyBundleProcessorTest_4.bundle
@@ -1,0 +1,71 @@
+<l7:Bundle xmlns:l7="http://ns.l7tech.com/2010/04/gateway-management">
+    <l7:References>
+        <l7:Item>
+            <l7:Name>Root Node</l7:Name>
+            <l7:Id>0000000000000000ffffffffffffec76</l7:Id>
+            <l7:Type>FOLDER</l7:Type>
+            <l7:Resource>
+                <l7:Folder id="0000000000000000ffffffffffffec76">
+                    <l7:Name>Root Node</l7:Name>
+                </l7:Folder>
+            </l7:Resource>
+        </l7:Item>
+        <l7:Item>
+            <l7:Name>Test Service Policy Using Test Encass 1</l7:Name>
+            <l7:Id>8a2584e2757d926c2ce29ac86256df9f</l7:Id>
+            <l7:Type>SERVICE</l7:Type>
+            <l7:Resource>
+                <l7:Service id="8a2584e2757d926c2ce29ac86256df9f">
+                    <l7:ServiceDetail folderId="0000000000000000ffffffffffffec76" id="8a2584e2757d926c2ce29ac86256df9f">
+                        <l7:Name>Test Service Policy Using Test Encass 1</l7:Name>
+                        <l7:Enabled>true</l7:Enabled>
+                        <l7:ServiceMappings>
+                            <l7:HttpMapping>
+                                <l7:UrlPattern>/test/*</l7:UrlPattern>
+                                <l7:Verbs>
+                                    <l7:Verb>OTHER</l7:Verb>
+                                    <l7:Verb>HEAD</l7:Verb>
+                                    <l7:Verb>DELETE</l7:Verb>
+                                    <l7:Verb>POST</l7:Verb>
+                                    <l7:Verb>GET</l7:Verb>
+                                    <l7:Verb>OPTIONS</l7:Verb>
+                                    <l7:Verb>PUT</l7:Verb>
+                                    <l7:Verb>PATCH</l7:Verb>
+                                </l7:Verbs>
+                            </l7:HttpMapping>
+                        </l7:ServiceMappings>
+                        <l7:Properties>
+                            <l7:Property key="wssProcessingEnabled">
+                                <l7:BooleanValue>false</l7:BooleanValue>
+                            </l7:Property>
+                        </l7:Properties>
+                    </l7:ServiceDetail>
+                    <l7:Resources>
+                        <l7:ResourceSet tag="policy">
+                            <l7:Resource type="policy">
+                                &lt;wsp:Policy xmlns:wsp="http://schemas.xmlsoap.org/ws/2002/12/policy" xmlns:L7p="http://www.layer7tech.com/ws/policy"&gt;
+                                &lt;wsp:All wsp:Usage="Required"&gt;
+                                &lt;L7p:Encapsulated&gt;
+                                &lt;L7p:EncapsulatedAssertionConfigGuid stringValue="00000000-0000-0000-0000-000000000000"/&gt;
+                                &lt;L7p:EncapsulatedAssertionConfigName stringValue="Test Encass 1"/&gt;
+                                &lt;L7p:Parameters mapValue="included"&gt;
+                                &lt;L7p:entry&gt;
+                                &lt;L7p:key stringValue="input"/&gt;
+                                &lt;L7p:value stringValue=""/&gt;
+                                &lt;/L7p:entry&gt;
+                                &lt;/L7p:Parameters&gt;
+                                &lt;/L7p:Encapsulated&gt;
+                                &lt;/wsp:All&gt;
+                                &lt;/wsp:Policy&gt;
+                            </l7:Resource>
+                        </l7:ResourceSet>
+                    </l7:Resources>
+                </l7:Service>
+            </l7:Resource>
+        </l7:Item>
+    </l7:References>
+    <l7:Mappings>
+        <l7:Mapping action="NewOrExisting" srcId="0000000000000000ffffffffffffec76" type="FOLDER"/>
+        <l7:Mapping action="NewOrExisting" srcId="b5f856df483ce1c5362a9ab401fb9161" type="ENCAPSULATED_ASSERTION"/>
+    </l7:Mappings>
+</l7:Bundle>


### PR DESCRIPTION
Fixes #DE419734 

## Proposed Changes
* Reading all dependency bundles prior to packaging to ensure that encapsulated assertions that were previously decoupled and are now available in the final build gets attached by ID - service policies were missing.
