### PR TITLE
DE419731 Splitting env properties into different files by type

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/ContextVariableEnvironmentProperty.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/ContextVariableEnvironmentProperty.java
@@ -26,6 +26,6 @@ public class ContextVariableEnvironmentProperty extends EnvironmentProperty {
 
     @Override
     public String getKey() {
-        return "contextVariable.property." + getName();
+        return getName();
     }
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/ContextVariableEnvironmentProperty.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/ContextVariableEnvironmentProperty.java
@@ -14,7 +14,7 @@ import javax.inject.Named;
 import static com.ca.apim.gateway.cagatewayconfig.config.spec.ConfigurationFile.FileType.PROPERTIES;
 
 @Named("CONTEXT_VARIABLE_ENVIRONMENT_PROPERTY")
-@ConfigurationFile(name = "env", type = PROPERTIES)
+@ConfigurationFile(name = "context-env", type = PROPERTIES)
 @EnvironmentType("CONTEXT_VARIABLE_PROPERTY")
 public class ContextVariableEnvironmentProperty extends EnvironmentProperty {
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/GlobalEnvironmentProperty.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/GlobalEnvironmentProperty.java
@@ -14,7 +14,7 @@ import javax.inject.Named;
 import static com.ca.apim.gateway.cagatewayconfig.config.spec.ConfigurationFile.FileType.PROPERTIES;
 
 @Named("ENVIRONMENT_PROPERTY")
-@ConfigurationFile(name = "env", type = PROPERTIES)
+@ConfigurationFile(name = "global-env", type = PROPERTIES)
 @EnvironmentType("PROPERTY")
 public class GlobalEnvironmentProperty extends EnvironmentProperty {
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/ServiceEnvironmentProperty.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/ServiceEnvironmentProperty.java
@@ -14,7 +14,7 @@ import javax.inject.Named;
 import static com.ca.apim.gateway.cagatewayconfig.config.spec.ConfigurationFile.FileType.PROPERTIES;
 
 @Named("SERVICE_ENVIRONMENT_PROPERTY")
-@ConfigurationFile(name = "env", type = PROPERTIES)
+@ConfigurationFile(name = "service-env", type = PROPERTIES)
 @EnvironmentType("SERVICE_PROPERTY")
 public class ServiceEnvironmentProperty extends EnvironmentProperty {
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/ServiceEnvironmentProperty.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/ServiceEnvironmentProperty.java
@@ -26,6 +26,6 @@ public class ServiceEnvironmentProperty extends EnvironmentProperty {
 
     @Override
     public String getKey() {
-        return "service.property." + getName();
+        return getName();
     }
 }

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ListenPortEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ListenPortEntityBuilder.java
@@ -110,7 +110,7 @@ public class ListenPortEntityBuilder implements EntityBuilder {
         String targetServiceReference = listenPort.getTargetServiceReference();
         Service service = bundle.getServices().get(targetServiceReference);
 
-        if (service == null) {
+        if (service == null || service.getId() == null) {
             service = getDeploymentBundle().getServices().get(targetServiceReference);
         }
 

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ListenPortEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/ListenPortEntityBuilderTest.java
@@ -110,6 +110,21 @@ class ListenPortEntityBuilderTest {
     }
 
     @Test
+    void buildWithCustomPortReferencingService() {
+        ListenPortEntityBuilder builder = new ListenPortEntityBuilder(ID_GENERATOR);
+        final Bundle bundle = new Bundle();
+        addPortToBundle(bundle, buildPortWithServiceRef());
+        Service service = new Service();
+        service.setId("service-id");
+        service.setName(SERVICE_REFERENCE);
+        bundle.getEntities(Service.class).put(SERVICE_REFERENCE, service);
+
+        final List<Entity> listenPortEntities = builder.build(bundle, BundleType.DEPLOYMENT, DocumentTools.INSTANCE.getDocumentBuilder().newDocument());
+        // check
+        checkExpectedPorts(listenPortEntities, TEST_HTTP_PORT);
+    }
+
+    @Test
     void checkDefaultPortsAreCreated() {
         final Map<String, ListenPort> defaultListenPorts = ListenPortEntityBuilder.createDefaultListenPorts();
 

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/config/loader/EnvironmentPropertiesLoaderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/config/loader/EnvironmentPropertiesLoaderTest.java
@@ -63,7 +63,7 @@ class EnvironmentPropertiesLoaderTest {
     void loadSinglePropertyFromFile() throws IOException {
         PropertiesLoaderBase loader = createPropertiesLoader(fileUtils, new IdGenerator(), createEntityInfo(GlobalEnvironmentProperty.class));
         final File configFolder = rootProjectDir.createDirectory("config");
-        final File identityProvidersFile = new File(configFolder, "env.properties");
+        final File identityProvidersFile = new File(configFolder, "global-env.properties");
         Files.touch(identityProvidersFile);
 
         when(fileUtils.getInputStream(any(File.class))).thenReturn(new ByteArrayInputStream("Prop1=value1\nProp2=value2\nProp3=Gateway".getBytes()));
@@ -128,7 +128,7 @@ class EnvironmentPropertiesLoaderTest {
         PropertiesLoaderBase loader = createPropertiesLoader(fileUtils, new IdGenerator(), createEntityInfo(GlobalEnvironmentProperty.class));
 
         final File configFolder = rootProjectDir.createDirectory("config");
-        final File identityProvidersFile = new File(configFolder, "env.properties");
+        final File identityProvidersFile = new File(configFolder, "global-env.properties");
         Files.touch(identityProvidersFile);
 
         InputStream stream = mock(InputStream.class);
@@ -143,7 +143,7 @@ class EnvironmentPropertiesLoaderTest {
         PropertiesLoaderBase loader = createPropertiesLoader(fileUtils, new IdGenerator(), createEntityInfo(GlobalEnvironmentProperty.class));
 
         final File configFolder = rootProjectDir.createDirectory("config");
-        final File identityProvidersFile = new File(configFolder, "env.properties");
+        final File identityProvidersFile = new File(configFolder, "global-env.properties");
         Files.touch(identityProvidersFile);
 
         when(fileUtils.getInputStream(any(File.class))).thenReturn(new ByteArrayInputStream(content.getBytes()));

--- a/environment-creator-application/src/test/java/com/ca/apim/gateway/cagatewayconfig/EnvironmentCreatorApplicationTest.java
+++ b/environment-creator-application/src/test/java/com/ca/apim/gateway/cagatewayconfig/EnvironmentCreatorApplicationTest.java
@@ -266,11 +266,11 @@ class EnvironmentCreatorApplicationTest {
                 defaultCharset()
         );
         writeStringToFile(
-                new File(envFolder, "env.properties"),
-                "my-gateway-api.myEnvironmentVariable=my-service-property-value\n" +
-                        "anotherEnvVar=context-variable-value",
+                new File(envFolder, "service-env.properties"),
+                "my-gateway-api.myEnvironmentVariable=my-service-property-value",
                 defaultCharset()
         );
+        writeStringToFile(new File( envFolder, "context-env.properties"), "anotherEnvVar=context-variable-value", defaultCharset());
 
         new EnvironmentCreatorApplication(
                 System.getenv(),
@@ -326,11 +326,11 @@ class EnvironmentCreatorApplicationTest {
         copyDirectory(new File(Objects.requireNonNull(getClass().getClassLoader().getResource("templatized-bundles")).toURI()), testTemplatizedBundlesFolder);
 
         writeStringToFile(
-                new File(envFolder, "env.properties"),
-                "my-gateway-api.myEnvironmentVariable=my-service-property-value\n" +
-                        "anotherEnvVar=context-variable-value",
+                new File(envFolder, "service-env.properties"),
+                "my-gateway-api.myEnvironmentVariable=my-service-property-value",
                 defaultCharset()
         );
+        writeStringToFile(new File( envFolder, "context-env.properties"), "anotherEnvVar=context-variable-value", defaultCharset());
 
         new EnvironmentCreatorApplication(
                 System.getenv(),

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/CAGatewayExportTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/CAGatewayExportTest.java
@@ -90,9 +90,9 @@ class CAGatewayExportTest {
         try (FileReader reader = new FileReader(new File(configDir, "context-env.properties"))) {
             environmentProperties.load(reader);
         }
-        assertTrue(environmentProperties.containsKey("contextVariable.property.environment-variable.empty-value"));
-        assertTrue(environmentProperties.containsKey("contextVariable.property.environment-variable.message-variable"));
-        assertTrue(environmentProperties.containsKey("contextVariable.property.environment-variable.local.env.var"));
+        assertTrue(environmentProperties.containsKey("environment-variable.empty-value"));
+        assertTrue(environmentProperties.containsKey("environment-variable.message-variable"));
+        assertTrue(environmentProperties.containsKey("environment-variable.local.env.var"));
 
         assertFalse(new File(configDir, "static.properties").exists());
 

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/CAGatewayExportTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/CAGatewayExportTest.java
@@ -79,15 +79,20 @@ class CAGatewayExportTest {
         File configDir = new File(exportDir, "config");
 
         Properties environmentProperties = new Properties();
-        try (FileReader reader = new FileReader(new File(configDir, "env.properties"))) {
+        try (FileReader reader = new FileReader(new File(configDir, "global-env.properties"))) {
             environmentProperties.load(reader);
         }
 
+        assertTrue(environmentProperties.containsKey("gateway.ENV.my-global-property"));
+        assertTrue(environmentProperties.containsKey("gateway.ENV.another.global"));
+
+        environmentProperties = new Properties();
+        try (FileReader reader = new FileReader(new File(configDir, "context-env.properties"))) {
+            environmentProperties.load(reader);
+        }
         assertTrue(environmentProperties.containsKey("contextVariable.property.environment-variable.empty-value"));
         assertTrue(environmentProperties.containsKey("contextVariable.property.environment-variable.message-variable"));
         assertTrue(environmentProperties.containsKey("contextVariable.property.environment-variable.local.env.var"));
-        assertTrue(environmentProperties.containsKey("gateway.ENV.my-global-property"));
-        assertTrue(environmentProperties.containsKey("gateway.ENV.another.global"));
 
         assertFalse(new File(configDir, "static.properties").exists());
 

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ServiceLinkerTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ServiceLinkerTest.java
@@ -57,7 +57,7 @@ class ServiceLinkerTest {
         ServiceEnvironmentProperty property = bundle.getServiceEnvironmentProperties().get("service.prop");
         assertNotNull(property);
         assertEquals("value2", property.getValue());
-        assertEquals("service.property.service.prop", property.getKey());
+        assertEquals("service.prop", property.getKey());
     }
 
     private void link(Bundle bundle, boolean serviceProperties) {


### PR DESCRIPTION
Fixes #DE419731

## Proposed Changes
* global env properties (cluster properties), service env properties (service properties) and context env properties (context variables) now have each own properties file when exported and this can be use to provide environment as well.
