### PR TITLE
Bugfix/de462019 resuable annotation

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
@@ -126,10 +126,12 @@ public class EncassEntityBuilder implements EntityBuilder {
 
         AnnotatedEntity annotatedEntity = annotatedBundle != null ? annotatedBundle.getAnnotatedEntity() : null;
         boolean isRedeployableBundle = false;
+        boolean isReusable = false;
         if (annotatedEntity != null) {
             isRedeployableBundle = annotatedEntity.isRedeployable();
+            isReusable = annotatedEntity.isReusable();
             annotatedEncassEntity = encass.getAnnotatedEntity();
-            if (encass.isReusable() || isAnnotatedEntity(encass, annotatedEntity)) {
+            if (isReusable || isAnnotatedEntity(encass, annotatedEntity)) {
                 //use the id and guid defined at reusable annotation or bundle annotation (if its annotated bundle)
                 if (annotatedEncassEntity.getGuid() != null) {
                     if (IdValidator.isValidGuid(annotatedEncassEntity.getGuid())) {
@@ -168,7 +170,7 @@ public class EncassEntityBuilder implements EntityBuilder {
         buildAndAppendPropertiesElement(properties, document, encassAssertionElement);
         Entity entity = getEntityWithNameMapping(ENCAPSULATED_ASSERTION_TYPE, name, encassName, id, encassAssertionElement, guid);
 
-        if (isRedeployableBundle || !(encass.isReusable() || isAnnotatedEntity(encass, annotatedEntity))) {
+        if (isRedeployableBundle || !(isReusable || isAnnotatedEntity(encass, annotatedEntity))) {
             entity.setMappingAction(MappingActions.NEW_OR_UPDATE);
         } else {
             entity.setMappingAction(MappingActions.NEW_OR_EXISTING);

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
@@ -133,18 +133,20 @@ public class EncassEntityBuilder implements EntityBuilder {
             annotatedEncassEntity = encass.getAnnotatedEntity();
             if (isReusable || isAnnotatedEntity(encass, annotatedEntity)) {
                 //use the id and guid defined at reusable annotation or bundle annotation (if its annotated bundle)
-                if (annotatedEncassEntity.getGuid() != null) {
-                    if (IdValidator.isValidGuid(annotatedEncassEntity.getGuid())) {
-                        guid = annotatedEncassEntity.getGuid();
-                    } else {
-                        LOGGER.log(Level.WARNING, "ignoring given invalid guid {0} for entity {1}", new String[]{annotatedEncassEntity.getGuid(), name});
+                if (annotatedEncassEntity != null) {
+                    if (annotatedEncassEntity.getGuid() != null) {
+                        if (IdValidator.isValidGuid(annotatedEncassEntity.getGuid())) {
+                            guid = annotatedEncassEntity.getGuid();
+                        } else {
+                            LOGGER.log(Level.WARNING, "ignoring given invalid guid {0} for entity {1}", new String[]{annotatedEncassEntity.getGuid(), name});
+                        }
                     }
-                }
-                if (annotatedEncassEntity.getId() != null) {
-                    if (IdValidator.isValidGoid(annotatedEncassEntity.getId())) {
-                        id = annotatedEncassEntity.getId();
-                    } else {
-                        LOGGER.log(Level.WARNING, "ignoring given invalid goid {0} for entity {1}", new String[]{annotatedEncassEntity.getId(), name});
+                    if (annotatedEncassEntity.getId() != null) {
+                        if (IdValidator.isValidGoid(annotatedEncassEntity.getId())) {
+                            id = annotatedEncassEntity.getId();
+                        } else {
+                            LOGGER.log(Level.WARNING, "ignoring given invalid goid {0} for entity {1}", new String[]{annotatedEncassEntity.getId(), name});
+                        }
                     }
                 }
             } else {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
@@ -84,7 +84,7 @@ public class PolicyEntityBuilder implements EntityBuilder {
             Policy policyEntity = (Policy) policy;
             if (annotatedEntity != null) {
                 AnnotatedEntity annotatedPolicyEntity = policyEntity.getAnnotatedEntity();
-                if (policyEntity.isReusable() || isAnnotatedEntity(policyEntity, annotatedEntity)) {
+                if (annotatedEntity.isReusable() || isAnnotatedEntity(policyEntity, annotatedEntity)) {
                     if (annotatedPolicyEntity.getId() != null) {
                         if(IdValidator.isValidGoid(annotatedPolicyEntity.getId())){
                             policyEntity.setId(annotatedPolicyEntity.getId());
@@ -150,7 +150,7 @@ public class PolicyEntityBuilder implements EntityBuilder {
         final String policyName;
         AnnotatedEntity annotatedEntity = annotatedBundle != null ? annotatedBundle.getAnnotatedEntity() : null;
         if (annotatedEntity != null) {
-            if (policy.isReusable() || isAnnotatedEntity(policy, annotatedEntity)) {
+            if (annotatedEntity.isReusable() || isAnnotatedEntity(policy, annotatedEntity)) {
                 policyName = policy.getName();
             } else {
                 policyName = annotatedBundle.getUniquePrefix() + policy.getName() + annotatedBundle.getUniqueSuffix();

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
@@ -85,18 +85,20 @@ public class PolicyEntityBuilder implements EntityBuilder {
             if (annotatedEntity != null) {
                 AnnotatedEntity annotatedPolicyEntity = policyEntity.getAnnotatedEntity();
                 if (annotatedEntity.isReusable() || isAnnotatedEntity(policyEntity, annotatedEntity)) {
-                    if (annotatedPolicyEntity.getId() != null) {
-                        if(IdValidator.isValidGoid(annotatedPolicyEntity.getId())){
-                            policyEntity.setId(annotatedPolicyEntity.getId());
-                        } else {
-                            LOGGER.log(Level.WARNING, "ignoring given invalid goid {0} for entity {1}", new String[]{annotatedPolicyEntity.getId(), policyEntity.getName()});
+                    if (annotatedPolicyEntity != null) {
+                        if (annotatedPolicyEntity.getId() != null) {
+                            if (IdValidator.isValidGoid(annotatedPolicyEntity.getId())) {
+                                policyEntity.setId(annotatedPolicyEntity.getId());
+                            } else {
+                                LOGGER.log(Level.WARNING, "ignoring given invalid goid {0} for entity {1}", new String[]{annotatedPolicyEntity.getId(), policyEntity.getName()});
+                            }
                         }
-                    }
-                    if (annotatedPolicyEntity.getGuid() != null) {
-                        if(IdValidator.isValidGuid(annotatedPolicyEntity.getGuid())){
-                            policyEntity.setGuid(annotatedPolicyEntity.getGuid());
-                        } else {
-                            LOGGER.log(Level.WARNING, "ignoring given invalid guid {0} for entity {1}", new String[]{annotatedPolicyEntity.getId(), policyEntity.getName()});
+                        if (annotatedPolicyEntity.getGuid() != null) {
+                            if (IdValidator.isValidGuid(annotatedPolicyEntity.getGuid())) {
+                                policyEntity.setGuid(annotatedPolicyEntity.getGuid());
+                            } else {
+                                LOGGER.log(Level.WARNING, "ignoring given invalid guid {0} for entity {1}", new String[]{annotatedPolicyEntity.getId(), policyEntity.getName()});
+                            }
                         }
                     }
                 } else {
@@ -366,21 +368,24 @@ public class PolicyEntityBuilder implements EntityBuilder {
         if (encass != null && !encass.isExcluded() && annotatedEntity != null) {
             AnnotatedEntity annotatedEncassEntity = encass.getAnnotatedEntity();
             if (annotatedEntity.isReusable()) {
-                if (annotatedEncassEntity.getGuid() != null) {
-                    if (IdValidator.isValidGuid(annotatedEncassEntity.getGuid())) {
-                        encassGuid = annotatedEncassEntity.getGuid();
-                        encass.setGuid(encassGuid);
-                    } else {
-                        LOGGER.log(Level.WARNING, "ignoring given invalid guid {0} for entity {1}", new String[]{annotatedEncassEntity.getGuid(), name});
+                if(annotatedEncassEntity != null){
+                    if (annotatedEncassEntity.getGuid() != null) {
+                        if (IdValidator.isValidGuid(annotatedEncassEntity.getGuid())) {
+                            encassGuid = annotatedEncassEntity.getGuid();
+                            encass.setGuid(encassGuid);
+                        } else {
+                            LOGGER.log(Level.WARNING, "ignoring given invalid guid {0} for entity {1}", new String[]{annotatedEncassEntity.getGuid(), name});
+                        }
+                    }
+                    if (annotatedEncassEntity.getId() != null) {
+                        if (IdValidator.isValidGoid(annotatedEncassEntity.getId())) {
+                            encass.setId(annotatedEncassEntity.getId());
+                        } else {
+                            LOGGER.log(Level.WARNING, "ignoring given invalid goid {0} for entity {1}", new String[]{annotatedEncassEntity.getId(), name});
+                        }
                     }
                 }
-                if (annotatedEncassEntity.getId() != null) {
-                    if (IdValidator.isValidGoid(annotatedEncassEntity.getId())) {
-                        encass.setId(annotatedEncassEntity.getId());
-                    } else {
-                        LOGGER.log(Level.WARNING, "ignoring given invalid goid {0} for entity {1}", new String[]{annotatedEncassEntity.getId(), name});
-                    }
-                }
+
             } else {
                 encassGuid = idGenerator.generateGuid();
                 encass.setGuid(encassGuid);

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
@@ -365,7 +365,7 @@ public class PolicyEntityBuilder implements EntityBuilder {
         AnnotatedEntity annotatedEntity = annotatedBundle != null ? annotatedBundle.getAnnotatedEntity() : null;
         if (encass != null && !encass.isExcluded() && annotatedEntity != null) {
             AnnotatedEntity annotatedEncassEntity = encass.getAnnotatedEntity();
-            if (encass.isReusable()) {
+            if (annotatedEntity.isReusable()) {
                 if (annotatedEncassEntity.getGuid() != null) {
                     if (IdValidator.isValidGuid(annotatedEncassEntity.getGuid())) {
                         encassGuid = annotatedEncassEntity.getGuid();
@@ -514,9 +514,14 @@ public class PolicyEntityBuilder implements EntityBuilder {
         String policyName = policy.getName();
         String policyNameWithPath = policy.getPath();
         AnnotatedEntity annotatedEntity = annotatedBundle != null ? annotatedBundle.getAnnotatedEntity() : null;
-        final boolean isRedeployableBundle = annotatedEntity != null && annotatedEntity.isRedeployable();
+        boolean isRedeployableBundle = false;
+        boolean isReusable = false;
+        if(annotatedEntity != null){
+            isRedeployableBundle = annotatedEntity.isRedeployable();
+            isReusable = annotatedEntity.isReusable();
+        }
         if (annotatedBundle != null) {
-            if (!policy.isReusable() && !isAnnotatedEntity(policy, annotatedEntity)) {
+            if (!isReusable && !isAnnotatedEntity(policy, annotatedEntity)) {
                 policyName = annotatedBundle.getUniquePrefix() + policyName + annotatedBundle.getUniqueSuffix();
                 policyNameWithPath = PathUtils.extractPath(policy.getPath()) + policyName;
             }
@@ -561,7 +566,7 @@ public class PolicyEntityBuilder implements EntityBuilder {
         policyElement.appendChild(resourcesElement);
         Entity entity = EntityBuilderHelper.getEntityWithPathMapping(EntityTypes.POLICY_TYPE,
                 policy.getPath(), policyNameWithPath, policy.getId(), policyElement, policy.isHasRouting());
-        if (isRedeployableBundle || !(policy.isReusable() || isAnnotatedEntity(policy, annotatedEntity))) {
+        if (isRedeployableBundle || !(isReusable || isAnnotatedEntity(policy, annotatedEntity))) {
             entity.setMappingAction(MappingActions.NEW_OR_UPDATE);
         } else {
             entity.setMappingAction(MappingActions.NEW_OR_EXISTING);

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilderTest.java
@@ -120,8 +120,8 @@ class BundleEntityBuilderTest {
         entityBuilders.add(policyBuilder);
         entityBuilders.add(encassBuilder);
 
-        buildAndValidateAnnotatedBundle(bundle, entityBuilders, "my-bundle-encass-TestEncass-" + TEST_ENCASS_POLICY + "-1.0", NEW_OR_UPDATE, TEST_ENCASS, NEW_OR_EXISTING,
-                TEST_DEP_ENCASS_POLICY, NEW_OR_EXISTING, "my-bundle-encass-TestEncass-" + TEST_DEP_ENCASS + "-1.0", NEW_OR_UPDATE);
+        buildAndValidateAnnotatedBundle(bundle, entityBuilders, TEST_ENCASS_POLICY, NEW_OR_EXISTING, TEST_ENCASS, NEW_OR_EXISTING,
+                TEST_DEP_ENCASS_POLICY, NEW_OR_EXISTING, TEST_DEP_ENCASS, NEW_OR_EXISTING);
     }
 
     @Test
@@ -172,7 +172,7 @@ class BundleEntityBuilderTest {
         entityBuilders.add(policyBuilder);
         entityBuilders.add(encassBuilder);
 
-        buildAndValidateAnnotatedBundle(bundle, entityBuilders, "my-bundle-encass-TestEncass-" + TEST_ENCASS_POLICY + "-1.0", NEW_OR_UPDATE, TEST_ENCASS, NEW_OR_UPDATE,
+        buildAndValidateAnnotatedBundle(bundle, entityBuilders, TEST_ENCASS_POLICY, NEW_OR_UPDATE, TEST_ENCASS, NEW_OR_UPDATE,
                 TEST_DEP_ENCASS_POLICY, NEW_OR_UPDATE, TEST_DEP_ENCASS, NEW_OR_UPDATE);
 
     }

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilderTest.java
@@ -141,9 +141,7 @@ class PolicyEntityBuilderTest {
         policy.setName(policy.getPath());
 
         Set<Annotation> annotations = new HashSet<>();
-        Annotation annotation = new Annotation(AnnotationConstants.ANNOTATION_TYPE_REUSABLE);
-        annotations.add(annotation);
-        annotation = new Annotation(AnnotationConstants.ANNOTATION_TYPE_BUNDLE_ENTITY);
+        Annotation annotation = new Annotation(AnnotationConstants.ANNOTATION_TYPE_BUNDLE_ENTITY);
         annotation.setGuid("");
         annotation.setId("");
         annotations.add(annotation);
@@ -152,8 +150,13 @@ class PolicyEntityBuilderTest {
         Encass encass = new Encass();
         encass.setGuid("encassGuid");
         encass.setName(TEST_ENCASS);
+        Annotation encassAnnotation = new Annotation(AnnotationConstants.ANNOTATION_TYPE_REUSABLE);
+        annotations = new HashSet<>();
+        annotations.add(encassAnnotation);
+        encass.setAnnotations(annotations);
         bundle.getEncasses().put(TEST_ENCASS, encass);
         bundle.getPolicies().put("Policy", policy);
+
 
         AnnotatedEntity annotatedEntity = new AnnotatedEntity(encass);
         annotatedEntity.setEntityName(encass.getName());


### PR DESCRIPTION
Fixes #
when there is reusable annotation on bundle entity all its children should be reusable
## Proposed Changes
* considering @reusable annotation on bundle annotated entity
* ignoring @reusable annotation on any other entity
* @bundle-entity any dependent entity is considered only when the parent has @reusable annotation 
