### PR TITLE
Bugfix/de466751 folder special chars

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/FolderEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/FolderEntityBuilder.java
@@ -16,9 +16,7 @@ import org.w3c.dom.Element;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.io.UnsupportedEncodingException;
 import java.util.*;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -48,11 +46,7 @@ public class FolderEntityBuilder implements EntityBuilder {
             folderElement.setAttribute(ATTRIBUTE_FOLDER_ID, parentFolderId);
         }
         String folderName = folder.getName();
-        try {
-            folderName = CharacterBlacklistUtil.decodeName(folderName);
-        } catch (UnsupportedEncodingException e) {
-            LOGGER.log(Level.WARNING, "unable to decode folder name " + folderName);
-        }
+        folderName = CharacterBlacklistUtil.decodeName(folderName);
         folderElement.appendChild(createElementWithTextContent(document, NAME, folderName));
         final Entity entity;
         if (parentFolderId == null) {
@@ -60,11 +54,7 @@ public class FolderEntityBuilder implements EntityBuilder {
             entity = new Entity(FOLDER_TYPE, folderName, id, folderElement, folder);
         } else {
             String filteredPathName = folder.getPath();
-            try {
-                filteredPathName = CharacterBlacklistUtil.decodePath(filteredPathName);
-            } catch (UnsupportedEncodingException e) {
-                LOGGER.log(Level.WARNING, "unable to decode folder path " + filteredPathName);
-            }
+            filteredPathName = CharacterBlacklistUtil.decodePath(filteredPathName);
             entity = EntityBuilderHelper.getEntityWithPathMapping(FOLDER_TYPE, filteredPathName, filteredPathName, id
                     , folderElement, false, folder);
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
@@ -14,6 +14,7 @@ import com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames;
 import com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingActions;
 import com.ca.apim.gateway.cagatewayconfig.util.paths.PathUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements;
+import com.ca.apim.gateway.cagatewayconfig.util.string.CharacterBlacklistUtil;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
 import com.google.common.annotations.VisibleForTesting;
@@ -26,6 +27,7 @@ import org.w3c.dom.*;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.io.UnsupportedEncodingException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
@@ -530,6 +532,11 @@ public class PolicyEntityBuilder implements EntityBuilder {
     Entity buildPolicyEntity(Policy policy, AnnotatedBundle annotatedBundle, Bundle bundle, Document document) {
         String policyName = policy.getName();
         String policyNameWithPath = policy.getPath();
+        try {
+            policyNameWithPath = CharacterBlacklistUtil.decodePath(policyNameWithPath);
+        } catch (UnsupportedEncodingException e) {
+            LOGGER.log(Level.WARNING, "unable to decode policy path " + policyNameWithPath);
+        }
         AnnotatedEntity annotatedEntity = annotatedBundle != null ? annotatedBundle.getAnnotatedEntity() : null;
         boolean isRedeployableBundle = false;
         boolean isReusable = false;
@@ -540,7 +547,7 @@ public class PolicyEntityBuilder implements EntityBuilder {
         if (annotatedBundle != null) {
             if (!isReusable && !isAnnotatedEntity(policy, annotatedEntity)) {
                 policyName = annotatedBundle.getUniquePrefix() + policyName;
-                policyNameWithPath = PathUtils.extractPath(policy.getPath()) + policyName;
+                policyNameWithPath = PathUtils.extractPath(policyNameWithPath) + policyName;
             }
         }
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
@@ -532,11 +532,7 @@ public class PolicyEntityBuilder implements EntityBuilder {
     Entity buildPolicyEntity(Policy policy, AnnotatedBundle annotatedBundle, Bundle bundle, Document document) {
         String policyName = policy.getName();
         String policyNameWithPath = policy.getPath();
-        try {
-            policyNameWithPath = CharacterBlacklistUtil.decodePath(policyNameWithPath);
-        } catch (UnsupportedEncodingException e) {
-            LOGGER.log(Level.WARNING, "unable to decode policy path " + policyNameWithPath);
-        }
+        policyNameWithPath = CharacterBlacklistUtil.decodePath(policyNameWithPath);
         AnnotatedEntity annotatedEntity = annotatedBundle != null ? annotatedBundle.getAnnotatedEntity() : null;
         boolean isRedeployableBundle = false;
         boolean isReusable = false;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/PolicyEntityBuilder.java
@@ -27,7 +27,6 @@ import org.w3c.dom.*;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import java.io.UnsupportedEncodingException;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/FolderLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/FolderLoader.java
@@ -42,11 +42,7 @@ public class FolderLoader implements BundleEntityLoader {
             parentFolder = ServiceAndPolicyLoaderUtil.getFolder(bundle, parentFolderID);
         }
 
-        try {
-            name = CharacterBlacklistUtil.encodeName(name);
-        } catch (UnsupportedEncodingException e) {
-            LOGGER.log(Level.WARNING, "unable to encode folder name " + name);
-        }
+        name = CharacterBlacklistUtil.encodeName(name);
 
         Folder folder = new Folder();
         folder.setId(id);

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/FolderLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/FolderLoader.java
@@ -13,10 +13,8 @@ import com.ca.apim.gateway.cagatewayconfig.util.string.CharacterBlacklistUtil;
 import org.w3c.dom.Element;
 
 import javax.inject.Singleton;
-import java.io.UnsupportedEncodingException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static com.ca.apim.gateway.cagatewayconfig.beans.Folder.ROOT_FOLDER_ID;

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtil.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtil.java
@@ -10,7 +10,6 @@ import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.util.Set;
-import java.util.StringTokenizer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtil.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtil.java
@@ -12,6 +12,7 @@ import java.net.URLEncoder;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.environment.CharacterBlacklist.getCharBlacklist;
 
@@ -19,6 +20,7 @@ import static com.ca.apim.gateway.cagatewayconfig.util.environment.CharacterBlac
  * Utility class for Character Blacklist. Purpose is to apply functions to the constants found in CharacterBlacklist
  */
 public class CharacterBlacklistUtil {
+    private static final Logger LOGGER = Logger.getLogger(CharacterBlacklistUtil.class.getName());
     private static final char REPLACEMENT_CHAR = '-';
 
     /**
@@ -81,15 +83,20 @@ public class CharacterBlacklistUtil {
     /**
      * Returns URL encoded name (even asterisk is encoded)
      */
-    public static String encodeName(String name) throws UnsupportedEncodingException {
-        String encodedName = URLEncoder.encode(name, "UTF-8");
-        return encodedName.replaceAll("\\*", "%2A");
+    public static String encodeName(String name) {
+        try {
+            String encodedName = URLEncoder.encode(name, "UTF-8");
+            return encodedName.replaceAll("\\*", "%2A");
+        } catch (UnsupportedEncodingException e) {
+            LOGGER.log(Level.WARNING, "unable to encode folder name " + name);
+            throw new RuntimeException("Unable to encode name " + name, e);
+        }
     }
 
     /**
      * Returns URL encoded path (even asterisk is encoded)
      */
-    public static String encodePath(String path) throws UnsupportedEncodingException {
+    public static String encodePath(String path) {
         if (path.equals("/")) {
             return path;
         }
@@ -100,7 +107,7 @@ public class CharacterBlacklistUtil {
             pathBuilder.append("/");
         }
         if (!path.endsWith("/")) {
-            pathBuilder.deleteCharAt(pathBuilder.length()-1);
+            pathBuilder.deleteCharAt(pathBuilder.length() - 1);
         }
         return pathBuilder.toString();
     }
@@ -108,7 +115,7 @@ public class CharacterBlacklistUtil {
     /**
      * Returns URL decoded path
      */
-    public static String decodePath(String path) throws UnsupportedEncodingException {
+    public static String decodePath(String path) {
         if (path.equals("/")) {
             return path;
         }
@@ -119,7 +126,7 @@ public class CharacterBlacklistUtil {
             pathBuilder.append("/");
         }
         if (!path.endsWith("/")) {
-            pathBuilder.deleteCharAt(pathBuilder.length()-1);
+            pathBuilder.deleteCharAt(pathBuilder.length() - 1);
         }
         return pathBuilder.toString();
     }
@@ -127,8 +134,14 @@ public class CharacterBlacklistUtil {
     /**
      * Returns URL decoded name
      */
-    public static String decodeName(String name) throws UnsupportedEncodingException {
-        return URLDecoder.decode(name, "UTF-8");
+    public static String decodeName(String name) {
+        try {
+            return URLDecoder.decode(name, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            LOGGER.log(Level.WARNING, "unable to decode folder name " + name);
+            throw new RuntimeException("Unable to decode name " + name, e);
+        }
+
     }
 
     private CharacterBlacklistUtil() {}

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtil.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtil.java
@@ -6,7 +6,12 @@
 
 package com.ca.apim.gateway.cagatewayconfig.util.string;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.util.Set;
+import java.util.StringTokenizer;
+import java.util.logging.Level;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.environment.CharacterBlacklist.getCharBlacklist;
 
@@ -71,6 +76,57 @@ public class CharacterBlacklistUtil {
         }
 
         return false;
+    }
+
+    /**
+     * Returns URL encoded name (even asterisk is encoded)
+     */
+    public static String encodeName(String name) throws UnsupportedEncodingException {
+        String encodedName = URLEncoder.encode(name, "UTF-8");
+        return encodedName.replaceAll("\\*", "%2A");
+    }
+
+    /**
+     * Returns URL encoded path (even asterisk is encoded)
+     */
+    public static String encodePath(String path) throws UnsupportedEncodingException {
+        if (path.equals("/")) {
+            return path;
+        }
+        final String[] folderNames = path.split("/");
+        StringBuilder pathBuilder = new StringBuilder();
+        for (int index = 0; index < folderNames.length; index++) {
+            pathBuilder.append(encodeName(folderNames[index]));
+            if (index < folderNames.length - 1) {
+                pathBuilder.append("/");
+            }
+        }
+        return pathBuilder.toString();
+    }
+
+    /**
+     * Returns URL decoded path
+     */
+    public static String decodePath(String path) throws UnsupportedEncodingException {
+        if (path.equals("/")) {
+            return path;
+        }
+        final String[] folderNames = path.split("/");
+        StringBuilder pathBuilder = new StringBuilder();
+        for (int index = 0; index < folderNames.length; index++) {
+            pathBuilder.append(decodeName(folderNames[index]));
+            if (index < folderNames.length - 1) {
+                pathBuilder.append("/");
+            }
+        }
+        return pathBuilder.toString();
+    }
+
+    /**
+     * Returns URL decoded name
+     */
+    public static String decodeName(String name) throws UnsupportedEncodingException {
+        return URLDecoder.decode(name, "UTF-8");
     }
 
     private CharacterBlacklistUtil() {}

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtil.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtil.java
@@ -95,11 +95,12 @@ public class CharacterBlacklistUtil {
         }
         final String[] folderNames = path.split("/");
         StringBuilder pathBuilder = new StringBuilder();
-        for (int index = 0; index < folderNames.length; index++) {
-            pathBuilder.append(encodeName(folderNames[index]));
-            if (index < folderNames.length - 1) {
-                pathBuilder.append("/");
-            }
+        for (String folderName : folderNames) {
+            pathBuilder.append(encodeName(folderName));
+            pathBuilder.append("/");
+        }
+        if (!path.endsWith("/")) {
+            pathBuilder.deleteCharAt(pathBuilder.length()-1);
         }
         return pathBuilder.toString();
     }
@@ -113,11 +114,12 @@ public class CharacterBlacklistUtil {
         }
         final String[] folderNames = path.split("/");
         StringBuilder pathBuilder = new StringBuilder();
-        for (int index = 0; index < folderNames.length; index++) {
-            pathBuilder.append(decodeName(folderNames[index]));
-            if (index < folderNames.length - 1) {
-                pathBuilder.append("/");
-            }
+        for (String folderName : folderNames) {
+            pathBuilder.append(decodeName(folderName));
+            pathBuilder.append("/");
+        }
+        if (!path.endsWith("/")) {
+            pathBuilder.deleteCharAt(pathBuilder.length()-1);
         }
         return pathBuilder.toString();
     }

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/FolderLoaderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/FolderLoaderTest.java
@@ -16,6 +16,8 @@ import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.nio.file.Paths;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
@@ -48,20 +50,21 @@ class FolderLoaderTest {
     }
 
     @Test
-    void loadWithInvalidCharName() {
+    void loadWithInvalidCharName() throws UnsupportedEncodingException {
         Document doc = DocumentTools.INSTANCE.getDocumentBuilder().newDocument();
         Bundle bundle = new Bundle();
-        bundle.getFolders().put(Folder.ROOT_FOLDER_NAME, Folder.ROOT_FOLDER);
-        Folder f1 = new Folder();
-        f1.setName(TEST_FOLDER_1 + "/1");
-        f1.setId(TEST_FOLDER_1);
-        bundle.getFolders().put(f1.getName(), f1);
-
-        assertThrows(BundleLoadException.class, () -> loader.load(bundle, createFolderXml(doc, f1.getName(), TEST_FOLDER_1, Folder.ROOT_FOLDER_ID)));
+        final String encodedRoot = URLEncoder.encode(Folder.ROOT_FOLDER_NAME, "UTF-8");
+        final String encodedTestFolder =  URLEncoder.encode(TEST_FOLDER_1 + "/1", "UTF-8");
+        loader.load(bundle, createFolderXml(doc, Folder.ROOT_FOLDER_NAME, Folder.ROOT_FOLDER_ID, null));
+        loader.load(bundle, createFolderXml(doc, TEST_FOLDER_1 + "/1", TEST_FOLDER_1, Folder.ROOT_FOLDER_ID));
+        assertNotNull(bundle.getFolders().get(encodedRoot));
+        assertEquals(encodedRoot, bundle.getFolders().get(encodedRoot).getName());
+        assertNotNull(bundle.getFolders().get(encodedTestFolder));
+        assertEquals(encodedTestFolder, bundle.getFolders().get(encodedTestFolder).getName());
     }
 
     @Test
-    void load() {
+    void load() throws UnsupportedEncodingException {
         Document doc = DocumentTools.INSTANCE.getDocumentBuilder().newDocument();
         Bundle bundle = new Bundle();
         loader.load(bundle, createFolderXml(doc, Folder.ROOT_FOLDER_NAME, Folder.ROOT_FOLDER_ID, null));
@@ -71,12 +74,13 @@ class FolderLoaderTest {
         assertFalse(bundle.getFolders().isEmpty());
         assertEquals(3, bundle.getFolders().size());
 
-        Folder root = bundle.getFolders().get(Folder.ROOT_FOLDER_NAME);
+        final String encodedRoot = URLEncoder.encode(Folder.ROOT_FOLDER_NAME, "UTF-8");
+        Folder root = bundle.getFolders().get(encodedRoot);
         assertNotNull(root);
         Assertions.assertEquals(Folder.ROOT_FOLDER_ID, root.getId());
-        Assertions.assertEquals(Folder.ROOT_FOLDER_NAME, root.getName());
+        Assertions.assertEquals(encodedRoot, root.getName());
         assertNull(root.getParentFolder());
-        Assertions.assertEquals(Folder.ROOT_FOLDER_NAME, root.getPath());
+        Assertions.assertEquals(encodedRoot, root.getPath());
 
         Folder folder1 = bundle.getFolders().get(TEST_FOLDER_1);
         assertNotNull(folder1);

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtilTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/util/string/CharacterBlacklistUtilTest.java
@@ -9,6 +9,7 @@ package com.ca.apim.gateway.cagatewayconfig.util.string;
 import com.ca.apim.gateway.cagatewayconfig.util.environment.CharacterBlacklist;
 import org.junit.jupiter.api.Test;
 
+import java.io.UnsupportedEncodingException;
 import java.util.stream.Stream;
 
 import static junit.framework.TestCase.assertTrue;
@@ -42,4 +43,51 @@ class CharacterBlacklistUtilTest {
     void containsNoInvalidCharacter() {
         assertFalse(CharacterBlacklistUtil.containsInvalidCharacter("example with no invalid characters"));
     }
+
+    @Test
+    void testEncodeAndDecodeName() throws UnsupportedEncodingException {
+        String name = "abc*:?|";
+        String encodeName = CharacterBlacklistUtil.encodeName(name);
+        String decodedName = CharacterBlacklistUtil.decodeName(encodeName);
+        assertEquals(decodedName, name);
+    }
+
+    @Test
+    void testEncodeAndDecodePath() throws UnsupportedEncodingException {
+        String path = "abc*:?|";
+        String encodedPath = CharacterBlacklistUtil.encodePath(path);
+        String decodedPath = CharacterBlacklistUtil.decodePath(encodedPath);
+        assertEquals(path, decodedPath);
+
+        path = "/abc*:?|";
+        encodedPath = CharacterBlacklistUtil.encodePath(path);
+        decodedPath = CharacterBlacklistUtil.decodePath(encodedPath);
+        assertEquals(path, decodedPath);
+
+        path = "/";
+        encodedPath = CharacterBlacklistUtil.encodePath(path);
+        decodedPath = CharacterBlacklistUtil.decodePath(encodedPath);
+        assertEquals(path, decodedPath);
+
+        path = "abc*:?|/test";
+        encodedPath = CharacterBlacklistUtil.encodePath(path);
+        decodedPath = CharacterBlacklistUtil.decodePath(encodedPath);
+        assertEquals(path, decodedPath);
+
+        path = "abc*:?|/test/";
+        encodedPath = CharacterBlacklistUtil.encodePath(path);
+        decodedPath = CharacterBlacklistUtil.decodePath(encodedPath);
+        assertEquals(path, decodedPath);
+
+        path = "/abc*:?|/test";
+        encodedPath = CharacterBlacklistUtil.encodePath(path);
+        decodedPath = CharacterBlacklistUtil.decodePath(encodedPath);
+        assertEquals(path, decodedPath);
+
+        path = "/abc*:?<>|/abc*:?<>/";
+        encodedPath = CharacterBlacklistUtil.encodePath(path);
+        decodedPath = CharacterBlacklistUtil.decodePath(encodedPath);
+        assertEquals(path, decodedPath);
+    }
+
 }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/ExplodeBundle.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/ExplodeBundle.java
@@ -23,13 +23,10 @@ import org.w3c.dom.Document;
 
 import javax.inject.Inject;
 import java.io.File;
-import java.io.UnsupportedEncodingException;
 import java.util.Collection;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class ExplodeBundle {
-    private static final Logger LOGGER = Logger.getLogger(ExplodeBundle.class.getName());
     private final DocumentTools documentTools;
     private final EntityWriterRegistry entityWriterRegistry;
     private final EntityLinkerRegistry entityLinkerRegistry;

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/ExplodeBundle.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/ExplodeBundle.java
@@ -60,11 +60,7 @@ public class ExplodeBundle {
         Bundle bundle = bundleBuilder.buildBundle(bundleDocument.getDocumentElement());
 
         String encodedFolderPath = folderPath;
-        try {
-            encodedFolderPath = CharacterBlacklistUtil.encodePath(folderPath);
-        } catch (UnsupportedEncodingException e) {
-            LOGGER.log(Level.WARNING, "unable to encode folder path " + folderPath);
-        }
+        encodedFolderPath = CharacterBlacklistUtil.encodePath(folderPath);
         //checks if bundle has specified folderpath
         if (!bundleContainsFolderPath(bundle, encodedFolderPath)) {
             throw new BundleLoadException("Specified folder " + folderPath + " does not exist in the target gateway.");


### PR DESCRIPTION
## Description
When folder has special characters (:?/\|*) the export task is failing
To solve this issue, folder name is URL encoded when exporting to config folder and folder name is decoded when generating bundle from config folder
## Links
Link Type   | Link
------      | ------
Rally Issue | 
Func Spec   | 
## Checklist
- [x] Pull Request Created
- [ ] Code Review Completed
- [ ] Veracode scan results addressed
- [ ] SonarQube scan results addressed
- [ ] TPSR has been submitted (if applicable) 
- [ ] Unit tests have been added
- [ ] Integration/Functional test cases have been written and automated
- [ ] Func Spec has been updated as needed
- [ ] Rally Issue(s) are in an engineering completed state 