### PR TITLE
Adding new system properties for annotations

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/IdentityProvider.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/IdentityProvider.java
@@ -43,7 +43,7 @@ public class IdentityProvider extends GatewayEntity implements AnnotableEntity {
         LDAP("LDAP"),
         FEDERATED("Federated"),
         BIND_ONLY_LDAP("Simple LDAP"),
-        POLICY_BACKED("Policy-backed");
+        POLICY_BACKED("Policy-Backed");
 
         private String value;
         IdentityProviderType(String value) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Service.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Service.java
@@ -26,6 +26,8 @@ import org.w3c.dom.Element;
 
 import javax.inject.Named;
 import java.io.File;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
@@ -43,9 +45,9 @@ public class Service extends Folderable implements AnnotableEntity {
     private String url;
     private String policy;
     private Set<String> httpMethods;
-    private Map<String,Object> properties;
+    private Map<String,Object> properties = new HashMap<>();
     @JsonDeserialize(using = AnnotationDeserializer.class)
-    private Set<Annotation> annotations;
+    private Set<Annotation> annotations = new HashSet<>();
     @JsonIgnore
     private Element serviceDetailsElement;
     @JsonIgnore

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
@@ -23,7 +23,6 @@ import java.util.*;
 import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.BuilderConstants.*;
 import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilder.BundleType.*;
@@ -108,7 +107,7 @@ public class BundleEntityBuilder {
     private Map<String, BundleArtifacts> buildAnnotatedEntities(BundleType bundleType, Bundle bundle,
                                                                 Document document, ProjectInfo projectInfo) {
         final Map<String, BundleArtifacts> annotatedElements = new LinkedHashMap<>();
-        if (EntityBuilderHelper.isIgnoreAnnotations()) {
+        if (EntityBuilderHelper.ignoreAnnotations()) {
             return annotatedElements;
         }
         Map<String, EntityUtils.GatewayEntityInfo> entityTypeMap = entityTypeRegistry.getEntityTypeMap();

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/BundleEntityBuilder.java
@@ -108,6 +108,9 @@ public class BundleEntityBuilder {
     private Map<String, BundleArtifacts> buildAnnotatedEntities(BundleType bundleType, Bundle bundle,
                                                                 Document document, ProjectInfo projectInfo) {
         final Map<String, BundleArtifacts> annotatedElements = new LinkedHashMap<>();
+        if (EntityBuilderHelper.isIgnoreAnnotations()) {
+            return annotatedElements;
+        }
         Map<String, EntityUtils.GatewayEntityInfo> entityTypeMap = entityTypeRegistry.getEntityTypeMap();
         // Filter the bundle to export only annotated entities
         entityTypeMap.values().stream().filter(EntityUtils.GatewayEntityInfo::isBundleGenerationSupported).forEach(entityInfo ->

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EntityBuilderHelper.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EntityBuilderHelper.java
@@ -29,41 +29,33 @@ import static com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingProperties
 class EntityBuilderHelper {
     private static final Logger LOGGER = Logger.getLogger(EntityBuilderHelper.class.getName());
     // TODO: reconsider the default value. NewOrExisting is the safest and acceptable action for most of the customer's scenarios.
-    private static final String DEFAULT_ENTITY_MAPPING_ACTION = NEW_OR_UPDATE;
-    private static final String DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY = "com.ca.apim.build.defaultEntityMappingAction";
-    private static String defaultEntityMappingAction;
+    public static final String DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY = "com.ca.apim.build.defaultEntityMappingAction";
+    public static final String DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY_DEFAULT = NEW_OR_UPDATE;
+    private static final Pattern DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY_PATTERN = Pattern.compile(NEW_OR_EXISTING + "|" + NEW_OR_UPDATE);
 
     private static final String IGNORE_ANNOTATIONS_PROPERTY = "com.ca.apim.build.ignoreAnnotations";
+    private static final String IGNORE_ANNOTATIONS_PROPERTY_DEFAULT = "false";
     private EntityBuilderHelper() {
     }
 
-    @VisibleForTesting
-    static void resetDefaultEntityMappingAction(String value) {
-        defaultEntityMappingAction = null;
-        System.setProperty(DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY, value != null ? value : DEFAULT_ENTITY_MAPPING_ACTION);
-    }
-
     static String getDefaultEntityMappingAction() {
-        if (defaultEntityMappingAction == null) {
-            String action = System.getProperty(DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY);
-            if (action == null ||
-                    !Pattern.matches(NEW_OR_EXISTING + "|" + NEW_OR_UPDATE, action)) {
-                action = DEFAULT_ENTITY_MAPPING_ACTION;
-            }
-            defaultEntityMappingAction = action;
-            LOGGER.info("Using default entity mapping action as " + defaultEntityMappingAction);
+        String action = System.getProperty(DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY,
+                DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY_DEFAULT);
+        if (!DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY_PATTERN.matcher(action).matches()) {
+            action = DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY_DEFAULT;
+            LOGGER.info("Using default entity mapping action as " + action);
         }
 
-        return defaultEntityMappingAction;
+        return action;
     }
 
     /**
      * Returns system property ignore annotations value, default is false
      * @return boolean
      */
-    static boolean isIgnoreAnnotations() {
-        final String ignoreAnnotations = System.getProperty(IGNORE_ANNOTATIONS_PROPERTY);
-        return ignoreAnnotations != null && "true".equals(ignoreAnnotations.trim());
+    static boolean ignoreAnnotations() {
+        return Boolean.parseBoolean(System.getProperty(IGNORE_ANNOTATIONS_PROPERTY,
+                IGNORE_ANNOTATIONS_PROPERTY_DEFAULT));
     }
 
     static Entity getEntityWithOnlyMapping(String entityType, String name, String id) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EntityBuilderHelper.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EntityBuilderHelper.java
@@ -34,7 +34,6 @@ class EntityBuilderHelper {
     private static String defaultEntityMappingAction;
 
     private static final String IGNORE_ANNOTATIONS_PROPERTY = "com.ca.apim.build.ignoreAnnotations";
-    private static final String IGNORE_ANNOTATIONS = System.getProperty(IGNORE_ANNOTATIONS_PROPERTY);
     private EntityBuilderHelper() {
     }
 
@@ -63,7 +62,8 @@ class EntityBuilderHelper {
      * @return boolean
      */
     static boolean isIgnoreAnnotations() {
-       return IGNORE_ANNOTATIONS != null && "true".equals(IGNORE_ANNOTATIONS.trim());
+        final String ignoreAnnotations = System.getProperty(IGNORE_ANNOTATIONS_PROPERTY);
+        return ignoreAnnotations != null && "true".equals(ignoreAnnotations.trim());
     }
 
     static Entity getEntityWithOnlyMapping(String entityType, String name, String id) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EntityBuilderHelper.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EntityBuilderHelper.java
@@ -33,6 +33,8 @@ class EntityBuilderHelper {
     private static final String DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY = "com.ca.apim.build.defaultEntityMappingAction";
     private static String defaultEntityMappingAction;
 
+    private static final String IGNORE_ANNOTATIONS_PROPERTY = "com.ca.apim.build.ignoreAnnotations";
+    private static final String IGNORE_ANNOTATIONS = System.getProperty(IGNORE_ANNOTATIONS_PROPERTY);
     private EntityBuilderHelper() {
     }
 
@@ -54,6 +56,14 @@ class EntityBuilderHelper {
         }
 
         return defaultEntityMappingAction;
+    }
+
+    /**
+     * Returns system property ignore annotations value, default is false
+     * @return boolean
+     */
+    static boolean isIgnoreAnnotations() {
+       return IGNORE_ANNOTATIONS != null && "true".equals(IGNORE_ANNOTATIONS.trim());
     }
 
     static Entity getEntityWithOnlyMapping(String entityType, String name, String id) {

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/EncassLoader.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/EncassLoader.java
@@ -7,21 +7,20 @@
 package com.ca.apim.gateway.cagatewayconfig.bundle.loader;
 
 import com.ca.apim.gateway.cagatewayconfig.beans.*;
+import com.ca.apim.gateway.cagatewayconfig.util.entity.AnnotationType;
 import com.ca.apim.gateway.cagatewayconfig.util.entity.EntityTypes;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 import javax.inject.Singleton;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static com.ca.apim.gateway.cagatewayconfig.bundle.loader.BundleLoadingOperation.VALIDATE;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BuilderUtils.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
+import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.L7_TEMPLATE;
 import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.POLICY_GUID_PROP;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.*;
 

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceAndPolicyLoaderUtil.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceAndPolicyLoaderUtil.java
@@ -4,6 +4,7 @@ import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.beans.Folder;
 import com.ca.apim.gateway.cagatewayconfig.beans.Folderable;
 import com.ca.apim.gateway.cagatewayconfig.util.paths.PathUtils;
+import com.google.common.annotations.VisibleForTesting;
 
 import java.nio.file.Paths;
 import java.util.List;
@@ -13,11 +14,16 @@ import java.util.stream.Collectors;
 public class ServiceAndPolicyLoaderUtil {
 
     public static final String HANDLE_DUPLICATE_NAMES = "com.ca.apim.export.handleDuplicateNames";
-    private static final String ANNOTATE_PORTAL_INTEGRATION_ASSERTIONS_PROP = "com.ca.apim.export.migratePortalIntegrationAssertions";
-    private static final String ANNOTATE_PORTAL_INTEGRATION_ASSERTIONS = System.getProperty(ANNOTATE_PORTAL_INTEGRATION_ASSERTIONS_PROP);
+    public static final String ANNOTATE_PORTAL_INTEGRATION_ASSERTIONS_PROP = "com.ca.apim.export.migratePortalIntegrationAssertions";
+    private static String ANNOTATE_PORTAL_INTEGRATION_ASSERTIONS = System.getProperty(ANNOTATE_PORTAL_INTEGRATION_ASSERTIONS_PROP);
 
     public static boolean isAnnotatePortalApisSet() {
         return ANNOTATE_PORTAL_INTEGRATION_ASSERTIONS != null && "true".equals(ANNOTATE_PORTAL_INTEGRATION_ASSERTIONS.trim());
+    }
+
+    @VisibleForTesting
+    public static void setAnnotatePortalIntegrationAssertion(String value) {
+        ANNOTATE_PORTAL_INTEGRATION_ASSERTIONS = value;
     }
 
     /**

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceAndPolicyLoaderUtil.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceAndPolicyLoaderUtil.java
@@ -4,7 +4,6 @@ import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.beans.Folder;
 import com.ca.apim.gateway.cagatewayconfig.beans.Folderable;
 import com.ca.apim.gateway.cagatewayconfig.util.paths.PathUtils;
-import com.google.common.annotations.VisibleForTesting;
 
 import java.nio.file.Paths;
 import java.util.List;
@@ -13,17 +12,19 @@ import java.util.stream.Collectors;
 
 public class ServiceAndPolicyLoaderUtil {
 
-    public static final String HANDLE_DUPLICATE_NAMES = "com.ca.apim.export.handleDuplicateNames";
-    public static final String ANNOTATE_PORTAL_INTEGRATION_ASSERTIONS_PROP = "com.ca.apim.export.migratePortalIntegrationAssertions";
-    private static String ANNOTATE_PORTAL_INTEGRATION_ASSERTIONS = System.getProperty(ANNOTATE_PORTAL_INTEGRATION_ASSERTIONS_PROP);
+    public static final String HANDLE_DUPLICATE_NAMES_PROPERTY = "com.ca.apim.export.handleDuplicateNames";
+    public static final String HANDLE_DUPLICATE_NAMES_PROPERTY_DEFAULT = "true";
+    public static final String MIGRATE_PORTAL_INTEGRATIONS_ASSERTIONS_PROPERTY = "com.ca.apim.export.migratePortalIntegrationAssertions";
+    public static final String MIGRATE_PORTAL_INTEGRATIONS_ASSERTIONS_PROPERTY_DEFAULT = "false";
 
-    public static boolean isAnnotatePortalApisSet() {
-        return ANNOTATE_PORTAL_INTEGRATION_ASSERTIONS != null && "true".equals(ANNOTATE_PORTAL_INTEGRATION_ASSERTIONS.trim());
+    public static boolean handleDuplicateNames() {
+        return Boolean.parseBoolean(System.getProperty(HANDLE_DUPLICATE_NAMES_PROPERTY,
+                HANDLE_DUPLICATE_NAMES_PROPERTY_DEFAULT));
     }
 
-    @VisibleForTesting
-    public static void setAnnotatePortalIntegrationAssertion(String value) {
-        ANNOTATE_PORTAL_INTEGRATION_ASSERTIONS = value;
+    public static boolean migratePortalIntegrationsAssertions() {
+        return Boolean.parseBoolean(System.getProperty(MIGRATE_PORTAL_INTEGRATIONS_ASSERTIONS_PROPERTY,
+                MIGRATE_PORTAL_INTEGRATIONS_ASSERTIONS_PROPERTY_DEFAULT));
     }
 
     /**
@@ -67,8 +68,8 @@ public class ServiceAndPolicyLoaderUtil {
         int duplicateCounter = 2;
         String basePath = entity.getPath();
         String clonePath = basePath;
-        final String handleDuplicates = System.getProperty(HANDLE_DUPLICATE_NAMES);
-        if (handleDuplicates == null || "true".equals(handleDuplicates.trim())) {
+
+        if (handleDuplicateNames()) {
             while (bundleEntity.containsKey(clonePath)) {
                 Folderable service = bundleEntity.get(clonePath);
                 if (!service.getId().equals(entity.getId())

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceAndPolicyLoaderUtil.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceAndPolicyLoaderUtil.java
@@ -13,6 +13,12 @@ import java.util.stream.Collectors;
 public class ServiceAndPolicyLoaderUtil {
 
     public static final String HANDLE_DUPLICATE_NAMES = "com.ca.apim.export.handleDuplicateNames";
+    private static final String ANNOTATE_PORTAL_INTEGRATION_ASSERTIONS_PROP = "com.ca.apim.export.migratePortalIntegrationAssertions";
+    private static final String ANNOTATE_PORTAL_INTEGRATION_ASSERTIONS = System.getProperty(ANNOTATE_PORTAL_INTEGRATION_ASSERTIONS_PROP);
+
+    public static boolean isAnnotatePortalApisSet() {
+        return ANNOTATE_PORTAL_INTEGRATION_ASSERTIONS != null && "true".equals(ANNOTATE_PORTAL_INTEGRATION_ASSERTIONS.trim());
+    }
 
     /**
      * Get path with file name
@@ -55,8 +61,8 @@ public class ServiceAndPolicyLoaderUtil {
         int duplicateCounter = 2;
         String basePath = entity.getPath();
         String clonePath = basePath;
-
-        if (Boolean.getBoolean(HANDLE_DUPLICATE_NAMES)) {
+        final String handleDuplicates = System.getProperty(HANDLE_DUPLICATE_NAMES);
+        if (handleDuplicates == null || "true".equals(handleDuplicates.trim())) {
             while (bundleEntity.containsKey(clonePath)) {
                 Folderable service = bundleEntity.get(clonePath);
                 if (!service.getId().equals(entity.getId())

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/policy/PolicyXMLElements.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/policy/PolicyXMLElements.java
@@ -26,6 +26,9 @@ public class PolicyXMLElements {
     public static final String ENCAPSULATED_ASSERTION_CONFIG_GUID = "L7p:EncapsulatedAssertionConfigGuid";
     public static final String ENCAPSULATED_ASSERTION_CONFIG_NAME = "L7p:EncapsulatedAssertionConfigName";
     public static final String API_PORTAL_ENCASS_INTEGRATION = "L7p:ApiPortalEncassIntegration";
+    public static final String API_PORTAL_INTEGRATION = "L7p:ApiPortalIntegration";
+    public static final String PORTAL_MANAGED_API_FLAG = "L7p:PortalManagedApiFlag";
+    public static final String API_PORTAL_SERVICE_ASSERTION = "L7p:ApiPortalManagedServiceAssertion";
     public static final String POLICY_GUID = "L7p:PolicyGuid";
     public static final String NO_OP_IF_CONFIG_MISSING = "L7p:NoOpIfConfigMissing";
     public static final String AUTHENTICATION = "L7p:Authentication";

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/policy/PolicyXMLElements.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/policy/PolicyXMLElements.java
@@ -13,6 +13,7 @@ public class PolicyXMLElements {
 
     public static final String GOID_VALUE = "goidValue";
     public static final String STRING_VALUE = "stringValue";
+    public static final String BOOLEAN_VALUE = "booleanValue";
     public static final String GOID_ARRAY_VALUE = "goidArrayValue";
     public static final String INCLUDE = "L7p:Include";
     public static final String ENCAPSULATED = "L7p:Encapsulated";
@@ -25,10 +26,16 @@ public class PolicyXMLElements {
     public static final String EXPRESSION = "L7p:Expression";
     public static final String ENCAPSULATED_ASSERTION_CONFIG_GUID = "L7p:EncapsulatedAssertionConfigGuid";
     public static final String ENCAPSULATED_ASSERTION_CONFIG_NAME = "L7p:EncapsulatedAssertionConfigName";
+    public static final String COMMENT_ASSERTION = "L7p:CommentAssertion";
+    public static final String COMMENT = "L7p:Comment";
     public static final String API_PORTAL_ENCASS_INTEGRATION = "L7p:ApiPortalEncassIntegration";
     public static final String API_PORTAL_INTEGRATION = "L7p:ApiPortalIntegration";
-    public static final String PORTAL_MANAGED_API_FLAG = "L7p:PortalManagedApiFlag";
-    public static final String API_PORTAL_SERVICE_ASSERTION = "L7p:ApiPortalManagedServiceAssertion";
+    public static final String API_PORTAL_INTEGRATION_FLAG = "L7p:PortalManagedApiFlag";
+    public static final String API_PORTAL_INTEGRATION_FLAG_SERVICE = "L7p:ApiPortalManagedServiceAssertion";
+    public static final String API_PORTAL_INTEGRATION_VARIABLE_PREFIX = "L7p:VariablePrefix";
+    public static final String API_PORTAL_INTEGRATION_API_ID = "L7p:ApiId";
+    public static final String API_PORTAL_INTEGRATION_API_GROUP = "L7p:ApiGroup";
+
     public static final String POLICY_GUID = "L7p:PolicyGuid";
     public static final String NO_OP_IF_CONFIG_MISSING = "L7p:NoOpIfConfigMissing";
     public static final String AUTHENTICATION = "L7p:Authentication";

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EntityBuilderHelperTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EntityBuilderHelperTest.java
@@ -7,7 +7,6 @@ import com.ca.apim.gateway.cagatewayconfig.util.gateway.MappingProperties;
 import com.ca.apim.gateway.cagatewayconfig.util.paths.PathUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
-import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -16,13 +15,16 @@ import org.w3c.dom.Document;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.regex.Pattern;
+
+import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilderHelper.DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY;
+import static com.ca.apim.gateway.cagatewayconfig.bundle.builder.EntityBuilderHelper.DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY_DEFAULT;
 
 public class EntityBuilderHelperTest {
 
     @Before
     public void beforeTest() {
-        EntityBuilderHelper.resetDefaultEntityMappingAction(null);
+        System.setProperty(DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY,
+                DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY_DEFAULT);
     }
 
     @Test
@@ -31,10 +33,10 @@ public class EntityBuilderHelperTest {
         Assert.assertTrue(MappingActions.NEW_OR_EXISTING.equals(EntityBuilderHelper.getDefaultEntityMappingAction()) ||
                 MappingActions.NEW_OR_UPDATE.equals(EntityBuilderHelper.getDefaultEntityMappingAction()));
 
-        EntityBuilderHelper.resetDefaultEntityMappingAction(MappingActions.NEW_OR_EXISTING);
+        System.setProperty(DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY, MappingActions.NEW_OR_EXISTING);
         Assert.assertEquals(MappingActions.NEW_OR_EXISTING, EntityBuilderHelper.getDefaultEntityMappingAction());
 
-        EntityBuilderHelper.resetDefaultEntityMappingAction(MappingActions.NEW_OR_UPDATE);
+        System.setProperty(DEFAULT_ENTITY_MAPPING_ACTION_PROPERTY, MappingActions.NEW_OR_UPDATE);
         Assert.assertEquals(MappingActions.NEW_OR_UPDATE, EntityBuilderHelper.getDefaultEntityMappingAction());
     }
 

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoaderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoaderTest.java
@@ -76,7 +76,7 @@ class ServiceLoaderTest {
         loader.load(bundle, createServiceXml(DocumentTools.INSTANCE.getDocumentBuilder().newDocument(),
                 true, true, false, false, false));
 
-        System.clearProperty(ServiceAndPolicyLoaderUtil.HANDLE_DUPLICATE_NAMES);
+        System.clearProperty(ServiceAndPolicyLoaderUtil.HANDLE_DUPLICATE_NAMES_PROPERTY);
 
         assertFalse(bundle.getServices().isEmpty());
         assertEquals(2, bundle.getServices().size());
@@ -107,7 +107,7 @@ class ServiceLoaderTest {
         folder.setName(TEST_FOLDER);
         folder.setPath(TEST_FOLDER);
         bundle.getFolders().put(TEST_FOLDER, folder);
-        System.setProperty(ServiceAndPolicyLoaderUtil.HANDLE_DUPLICATE_NAMES, "false");
+        System.setProperty(ServiceAndPolicyLoaderUtil.HANDLE_DUPLICATE_NAMES_PROPERTY, "false");
         loader.load(bundle, createServiceXml(DocumentTools.INSTANCE.getDocumentBuilder().newDocument(),
                 true, false, false, false, false));
 

--- a/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoaderTest.java
+++ b/config-builder/src/test/java/com/ca/apim/gateway/cagatewayconfig/bundle/loader/ServiceLoaderTest.java
@@ -68,7 +68,6 @@ class ServiceLoaderTest {
         folder.setName(TEST_FOLDER);
         folder.setPath(TEST_FOLDER);
         bundle.getFolders().put(TEST_FOLDER, folder);
-        System.setProperty(ServiceAndPolicyLoaderUtil.HANDLE_DUPLICATE_NAMES, "true");
 
         loader.load(bundle, createServiceXml(DocumentTools.INSTANCE.getDocumentBuilder().newDocument(),
                 true, false, false, false, false));
@@ -108,7 +107,7 @@ class ServiceLoaderTest {
         folder.setName(TEST_FOLDER);
         folder.setPath(TEST_FOLDER);
         bundle.getFolders().put(TEST_FOLDER, folder);
-
+        System.setProperty(ServiceAndPolicyLoaderUtil.HANDLE_DUPLICATE_NAMES, "false");
         loader.load(bundle, createServiceXml(DocumentTools.INSTANCE.getDocumentBuilder().newDocument(),
                 true, false, false, false, false));
 

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinker.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinker.java
@@ -17,8 +17,8 @@ import com.ca.apim.gateway.cagatewayexport.util.policy.EncassPolicyXMLSimplifier
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
+import java.util.Collections;
 import java.util.HashSet;
-import java.util.Set;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.L7_TEMPLATE;
 import static com.ca.apim.gateway.cagatewayexport.tasks.explode.linker.PolicyLinker.getPolicyPath;
@@ -43,13 +43,10 @@ public class EncassLinker implements EntityLinker<Encass> {
         if (policy == null) {
             throw new LinkerException("Could not find policy for Encapsulated Assertion: " + encass.getName() + ". Policy ID: " + encass.getPolicyId());
         }
-        final String l7template = encassPolicyXMLSimplifier.simplifyEncassPolicyXML(policy);
-        encass.getProperties().put(L7_TEMPLATE, l7template);
-        if ("true".equals(l7template) && ServiceAndPolicyLoaderUtil.migratePortalIntegrationsAssertions()) {
-            Set<Annotation> annotations = new HashSet<>();
-            Annotation bundleEntity = new Annotation(AnnotationType.BUNDLE);
-            annotations.add(bundleEntity);
-            encass.setAnnotations(annotations);
+        encassPolicyXMLSimplifier.simplifyEncassPolicyXML(policy.getPolicyDocument(), encass);
+        if ("true".equals(encass.getProperties().get(L7_TEMPLATE)) &&
+                ServiceAndPolicyLoaderUtil.migratePortalIntegrationsAssertions() && !encass.isBundle()) {
+            encass.setAnnotations(new HashSet<>(Collections.singletonList(new Annotation(AnnotationType.BUNDLE))));
         }
         encass.setPolicy(policy.getPath());
         encass.setPath(getPolicyPath(policy, bundle, encass));

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinker.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinker.java
@@ -45,7 +45,7 @@ public class EncassLinker implements EntityLinker<Encass> {
         }
         final String l7template = encassPolicyXMLSimplifier.simplifyEncassPolicyXML(policy);
         encass.getProperties().put(L7_TEMPLATE, l7template);
-        if ("true".equals(l7template) && ServiceAndPolicyLoaderUtil.isAnnotatePortalApisSet()) {
+        if ("true".equals(l7template) && ServiceAndPolicyLoaderUtil.migratePortalIntegrationsAssertions()) {
             Set<Annotation> annotations = new HashSet<>();
             Annotation bundleEntity = new Annotation(AnnotationType.BUNDLE);
             annotations.add(bundleEntity);

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinker.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinker.java
@@ -6,13 +6,19 @@
 
 package com.ca.apim.gateway.cagatewayexport.tasks.explode.linker;
 
+import com.ca.apim.gateway.cagatewayconfig.beans.Annotation;
 import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
 import com.ca.apim.gateway.cagatewayconfig.beans.Encass;
 import com.ca.apim.gateway.cagatewayconfig.beans.Policy;
+import com.ca.apim.gateway.cagatewayconfig.bundle.loader.ServiceAndPolicyLoaderUtil;
+import com.ca.apim.gateway.cagatewayconfig.util.entity.AnnotationType;
 import com.ca.apim.gateway.cagatewayexport.util.policy.EncassPolicyXMLSimplifier;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+
+import java.util.HashSet;
+import java.util.Set;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.L7_TEMPLATE;
 import static com.ca.apim.gateway.cagatewayexport.tasks.explode.linker.PolicyLinker.getPolicyPath;
@@ -37,8 +43,14 @@ public class EncassLinker implements EntityLinker<Encass> {
         if (policy == null) {
             throw new LinkerException("Could not find policy for Encapsulated Assertion: " + encass.getName() + ". Policy ID: " + encass.getPolicyId());
         }
-
-        encass.getProperties().put(L7_TEMPLATE, encassPolicyXMLSimplifier.simplifyEncassPolicyXML(policy));
+        final String l7template = encassPolicyXMLSimplifier.simplifyEncassPolicyXML(policy);
+        encass.getProperties().put(L7_TEMPLATE, l7template);
+        if ("true".equals(l7template) && ServiceAndPolicyLoaderUtil.isAnnotatePortalApisSet()) {
+            Set<Annotation> annotations = new HashSet<>();
+            Annotation bundleEntity = new Annotation(AnnotationType.BUNDLE);
+            annotations.add(bundleEntity);
+            encass.setAnnotations(annotations);
+        }
         encass.setPolicy(policy.getPath());
         encass.setPath(getPolicyPath(policy, bundle, encass));
     }

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ServiceLinker.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ServiceLinker.java
@@ -6,35 +6,40 @@
 
 package com.ca.apim.gateway.cagatewayexport.tasks.explode.linker;
 
-import com.ca.apim.gateway.cagatewayconfig.beans.Bundle;
-import com.ca.apim.gateway.cagatewayconfig.beans.ServiceEnvironmentProperty;
-import com.ca.apim.gateway.cagatewayconfig.beans.Folder;
-import com.ca.apim.gateway.cagatewayconfig.beans.Service;
+import com.ca.apim.gateway.cagatewayconfig.beans.*;
+import com.ca.apim.gateway.cagatewayconfig.bundle.loader.ServiceAndPolicyLoaderUtil;
+import com.ca.apim.gateway.cagatewayconfig.util.entity.AnnotationType;
 import com.ca.apim.gateway.cagatewayconfig.util.paths.PathUtils;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils;
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.writer.WriteException;
 import com.ca.apim.gateway.cagatewayexport.util.policy.PolicyXMLSimplifier;
+import com.ca.apim.gateway.cagatewayexport.util.policy.ServicePolicyXMLSimplifier;
 import org.w3c.dom.Element;
 import org.w3c.dom.NodeList;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
+import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.L7_TEMPLATE;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleChildElement;
 
 @Singleton
 public class ServiceLinker implements EntityLinker<Service> {
     private final DocumentTools documentTools;
     private final PolicyXMLSimplifier policyXMLSimplifier;
+    private final ServicePolicyXMLSimplifier servicePolicyXMLSimplifier;
 
     @Inject
-    ServiceLinker(DocumentTools documentTools, PolicyXMLSimplifier policyXMLSimplifier) {
+    ServiceLinker(DocumentTools documentTools, PolicyXMLSimplifier policyXMLSimplifier, ServicePolicyXMLSimplifier servicePolicyXMLSimplifier) {
         this.documentTools = documentTools;
         this.policyXMLSimplifier = policyXMLSimplifier;
+        this.servicePolicyXMLSimplifier = servicePolicyXMLSimplifier;
     }
 
     @Override
@@ -44,9 +49,11 @@ public class ServiceLinker implements EntityLinker<Service> {
 
     @Override
     public void link(Service service, Bundle bundle, Bundle targetBundle) {
+        String portalManagedService;
         try {
             Element policyElement = DocumentUtils.stringToXML(documentTools, service.getPolicy());
             policyXMLSimplifier.simplifyPolicyXML(policyElement, service.getName(), bundle, targetBundle);
+            portalManagedService = servicePolicyXMLSimplifier.simplifyServicePolicyXML(policyElement);
             service.setPolicyXML(policyElement);
         } catch (DocumentParseException e) {
             throw new WriteException("Exception linking and simplifying service: " + service.getName() + " Message: " + e.getMessage(), e);
@@ -63,6 +70,13 @@ public class ServiceLinker implements EntityLinker<Service> {
                         getSingleChildElement((Element) propertyNodes.item(i), STRING_VALUE).getTextContent());
                 targetBundle.getEntities(ServiceEnvironmentProperty.class).put(serviceEnvironmentProperty.getName(), serviceEnvironmentProperty);
             }
+        }
+
+        if ("true".equals(portalManagedService) && ServiceAndPolicyLoaderUtil.isAnnotatePortalApisSet()) {
+            Set<Annotation> annotations = new HashSet<>();
+            Annotation bundleEntity = new Annotation(AnnotationType.BUNDLE);
+            annotations.add(bundleEntity);
+            service.setAnnotations(annotations);
         }
     }
 

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ServiceLinker.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ServiceLinker.java
@@ -22,10 +22,11 @@ import org.w3c.dom.NodeList;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.HashSet;
-import java.util.Set;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
+import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.L7_TEMPLATE;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleChildElement;
 
 @Singleton
@@ -52,7 +53,7 @@ public class ServiceLinker implements EntityLinker<Service> {
         try {
             Element policyElement = DocumentUtils.stringToXML(documentTools, service.getPolicy());
             policyXMLSimplifier.simplifyPolicyXML(policyElement, service.getName(), bundle, targetBundle);
-            portalManagedService = servicePolicyXMLSimplifier.simplifyServicePolicyXML(policyElement);
+            servicePolicyXMLSimplifier.simplifyServicePolicyXML(policyElement, service);
             service.setPolicyXML(policyElement);
         } catch (DocumentParseException e) {
             throw new WriteException("Exception linking and simplifying service: " + service.getName() + " Message: " + e.getMessage(), e);
@@ -71,11 +72,9 @@ public class ServiceLinker implements EntityLinker<Service> {
             }
         }
 
-        if ("true".equals(portalManagedService) && ServiceAndPolicyLoaderUtil.migratePortalIntegrationsAssertions()) {
-            Set<Annotation> annotations = new HashSet<>();
-            Annotation bundleEntity = new Annotation(AnnotationType.BUNDLE);
-            annotations.add(bundleEntity);
-            service.setAnnotations(annotations);
+        if ("true".equals(service.getProperties().get(L7_TEMPLATE)) &&
+                ServiceAndPolicyLoaderUtil.migratePortalIntegrationsAssertions() && !service.isBundle()) {
+            service.setAnnotations(new HashSet<>(Collections.singletonList(new Annotation(AnnotationType.BUNDLE))));
         }
     }
 

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ServiceLinker.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ServiceLinker.java
@@ -26,7 +26,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.*;
-import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.L7_TEMPLATE;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleChildElement;
 
 @Singleton
@@ -72,7 +71,7 @@ public class ServiceLinker implements EntityLinker<Service> {
             }
         }
 
-        if ("true".equals(portalManagedService) && ServiceAndPolicyLoaderUtil.isAnnotatePortalApisSet()) {
+        if ("true".equals(portalManagedService) && ServiceAndPolicyLoaderUtil.migratePortalIntegrationsAssertions()) {
             Set<Annotation> annotations = new HashSet<>();
             Annotation bundleEntity = new Annotation(AnnotationType.BUNDLE);
             annotations.add(bundleEntity);

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/ServicePolicyXMLSimplifier.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/ServicePolicyXMLSimplifier.java
@@ -1,0 +1,41 @@
+package com.ca.apim.gateway.cagatewayexport.util.policy;
+
+import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
+import org.w3c.dom.Element;
+
+import javax.inject.Singleton;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.*;
+import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleChildElement;
+import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleElement;
+
+
+@Singleton
+public class ServicePolicyXMLSimplifier {
+    private static final Logger LOGGER = Logger.getLogger(ServicePolicyXMLSimplifier.class.getName());
+    /**
+     *
+     * @param policyElement service policy element.
+     * @return true if ApiPortalIntegration assertion is present and PortalManagedApiFlag is ApiPortalManagedServiceAssertion.
+     */
+    public String simplifyServicePolicyXML(Element policyElement) {
+        Element portalIntegrationElement = null;
+        String portalManagedApiFlag = null;
+        try {
+            portalIntegrationElement = getSingleElement(policyElement, API_PORTAL_INTEGRATION);
+        } catch (DocumentParseException e) {
+            LOGGER.log(Level.INFO, "ApiPortalIntegration assertion is not found in service policy");
+        }
+
+        if (portalIntegrationElement != null) {
+            Element portalManagedApiFlagElement = getSingleChildElement(portalIntegrationElement, PORTAL_MANAGED_API_FLAG, true);
+            if(portalManagedApiFlagElement != null){
+                portalManagedApiFlag = portalManagedApiFlagElement.getAttribute(API_PORTAL_SERVICE_ASSERTION);
+                portalIntegrationElement.removeChild(portalManagedApiFlagElement);
+            }
+        }
+        return Boolean.toString(portalManagedApiFlag != null);
+    }
+}

--- a/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/ServicePolicyXMLSimplifier.java
+++ b/gateway-export-plugin/src/main/java/com/ca/apim/gateway/cagatewayexport/util/policy/ServicePolicyXMLSimplifier.java
@@ -1,13 +1,20 @@
 package com.ca.apim.gateway.cagatewayexport.util.policy;
 
+import com.ca.apim.gateway.cagatewayconfig.beans.Service;
+import com.ca.apim.gateway.cagatewayconfig.bundle.loader.ServiceAndPolicyLoaderUtil;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
+import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
+import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import javax.inject.Singleton;
-import java.util.logging.Level;
+import java.util.Base64;
 import java.util.logging.Logger;
 
 import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.*;
+import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.L7_TEMPLATE;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleChildElement;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleElement;
 
@@ -18,24 +25,62 @@ public class ServicePolicyXMLSimplifier {
     /**
      *
      * @param policyElement service policy element.
-     * @return true if ApiPortalIntegration assertion is present and PortalManagedApiFlag is ApiPortalManagedServiceAssertion.
+     * @param service Service
      */
-    public String simplifyServicePolicyXML(Element policyElement) {
-        Element portalIntegrationElement = null;
-        String portalManagedApiFlag = null;
-        try {
-            portalIntegrationElement = getSingleElement(policyElement, API_PORTAL_INTEGRATION);
-        } catch (DocumentParseException e) {
-            LOGGER.log(Level.INFO, "ApiPortalIntegration assertion is not found in service policy");
-        }
+    public void simplifyServicePolicyXML(Element policyElement, Service service) {
+        service.getProperties().putIfAbsent(L7_TEMPLATE, "false");
+        // [Set as Portal Managed Service] assertion
+        simplifyPortalManagedAssertion(policyElement, service);
+    }
 
-        if (portalIntegrationElement != null) {
-            Element portalManagedApiFlagElement = getSingleChildElement(portalIntegrationElement, PORTAL_MANAGED_API_FLAG, true);
-            if(portalManagedApiFlagElement != null){
-                portalManagedApiFlag = portalManagedApiFlagElement.getAttribute(API_PORTAL_SERVICE_ASSERTION);
-                portalIntegrationElement.removeChild(portalManagedApiFlagElement);
+    private void simplifyPortalManagedAssertion(Element policyElement, Service service) {
+        try {
+            Element portalManagedElement = getSingleElement(policyElement, API_PORTAL_INTEGRATION);
+            Element flagElement = getSingleChildElement(portalManagedElement, API_PORTAL_INTEGRATION_FLAG, true);
+
+            if (flagElement != null && API_PORTAL_INTEGRATION_FLAG_SERVICE.equals(flagElement.getAttribute(STRING_VALUE))) {
+                Element enabledElement = getSingleChildElement(portalManagedElement, ENABLED, true);
+                Element variablePrefixElement = getSingleChildElement(portalManagedElement, API_PORTAL_INTEGRATION_VARIABLE_PREFIX, true);
+                Element apiIdElement = getSingleChildElement(portalManagedElement, API_PORTAL_INTEGRATION_API_ID, true);
+                Element apiGroupElement = getSingleChildElement(portalManagedElement, API_PORTAL_INTEGRATION_API_GROUP, true);
+                Document document = policyElement.getOwnerDocument();
+                Element parentElement = (Element) portalManagedElement.getParentNode();
+                boolean isEnabled = enabledElement == null || Boolean.parseBoolean(enabledElement.getAttribute(BOOLEAN_VALUE));
+                String variablePrefix = variablePrefixElement != null ? variablePrefixElement.getAttribute(STRING_VALUE) : "portal.managed.service";
+
+                service.getProperties().put(L7_TEMPLATE, Boolean.toString(isEnabled));
+                if (isEnabled && ServiceAndPolicyLoaderUtil.migratePortalIntegrationsAssertions()) {
+                    LOGGER.info("Migrating [Set as Portal Managed Service] assertion for " + service.getPath());
+                    parentElement.insertBefore(
+                            DocumentUtils.createElementWithChildren(document, COMMENT_ASSERTION,
+                                    DocumentUtils.createElementWithAttribute(document, COMMENT, STRING_VALUE, "Migrated: Set as Portal Managed Service")),
+                            portalManagedElement);
+                    if (apiIdElement != null) {
+                        parentElement.insertBefore(
+                                createSetAssertion(policyElement, variablePrefix + ".apiId", apiIdElement.getAttribute(STRING_VALUE)),
+                                portalManagedElement);
+                    }
+
+                    if (apiGroupElement != null) {
+                        parentElement.insertBefore(
+                                createSetAssertion(policyElement, variablePrefix + ".apiGroup", apiGroupElement.getAttribute(STRING_VALUE)),
+                                portalManagedElement);
+                    }
+                    parentElement.removeChild(portalManagedElement);
+                }
             }
+        } catch (DocumentParseException e) {
+            // ignoring the exception
         }
-        return Boolean.toString(portalManagedApiFlag != null);
+    }
+
+    private Element createSetAssertion(Element policyElement, String name, String value) {
+        Document document = policyElement.getOwnerDocument();
+        Element expressionElement = document.createElement(EXPRESSION);
+
+        expressionElement.appendChild(document.createCDATASection(StringEscapeUtils.escapeXml11(value)));
+        return DocumentUtils.createElementWithChildren(document, SET_VARIABLE,
+                DocumentUtils.createElementWithAttribute(document, VARIABLE_TO_SET, STRING_VALUE, name),
+                expressionElement);
     }
 }

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinkerTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinkerTest.java
@@ -131,7 +131,7 @@ class EncassLinkerTest {
         assertTrue(annotations.isEmpty());
 
         Policy updatedPolicy =  fullBundle.getEntities(Policy.class).get("1");
-        assertThrows(DocumentParseException.class, () -> getSingleElement(updatedPolicy.getPolicyDocument(), API_PORTAL_ENCASS_INTEGRATION));
+        assertDoesNotThrow(() -> getSingleElement(updatedPolicy.getPolicyDocument(), API_PORTAL_ENCASS_INTEGRATION));
     }
 
     @Test
@@ -154,7 +154,7 @@ class EncassLinkerTest {
         Set<Annotation> annotations = linkedEncass.getAnnotations();
         assertTrue(annotations.isEmpty());
         Policy updatedPolicy =  fullBundle.getEntities(Policy.class).get("1");
-        assertThrows(DocumentParseException.class, () -> getSingleElement(updatedPolicy.getPolicyDocument(), API_PORTAL_ENCASS_INTEGRATION));
+        assertDoesNotThrow(() -> getSingleElement(updatedPolicy.getPolicyDocument(), API_PORTAL_ENCASS_INTEGRATION));
     }
 
     @Test
@@ -204,7 +204,7 @@ class EncassLinkerTest {
         Set<Annotation> annotations = linkedEncass.getAnnotations();
         assertTrue(annotations.isEmpty());
         Policy updatedPolicy =  fullBundle.getEntities(Policy.class).get("1");
-        assertThrows(DocumentParseException.class, () -> getSingleElement(updatedPolicy.getPolicyDocument(), API_PORTAL_ENCASS_INTEGRATION));
+        assertDoesNotThrow(() -> getSingleElement(updatedPolicy.getPolicyDocument(), API_PORTAL_ENCASS_INTEGRATION));
     }
 
 }

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinkerTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/EncassLinkerTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Set;
 
+import static com.ca.apim.gateway.cagatewayconfig.bundle.loader.ServiceAndPolicyLoaderUtil.MIGRATE_PORTAL_INTEGRATIONS_ASSERTIONS_PROPERTY;
 import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.API_PORTAL_ENCASS_INTEGRATION;
 import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.*;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleElement;
@@ -55,6 +56,8 @@ class EncassLinkerTest {
 
     @BeforeEach
     void setUp() {
+        System.setProperty(MIGRATE_PORTAL_INTEGRATIONS_ASSERTIONS_PROPERTY,
+                ServiceAndPolicyLoaderUtil.MIGRATE_PORTAL_INTEGRATIONS_ASSERTIONS_PROPERTY_DEFAULT);
         encassLinker = new EncassLinker(new EncassPolicyXMLSimplifier());
         myEncass = createEncass("myEncass", "1", "1", "1");
         bundle = new Bundle();
@@ -110,7 +113,6 @@ class EncassLinkerTest {
     @Test
     void linkPortalTemplateFlag() throws DocumentParseException {
         Bundle fullBundle = new Bundle();
-        ServiceAndPolicyLoaderUtil.setAnnotatePortalIntegrationAssertion("false");
         myEncass.setProperties(new HashMap<String, Object>() {{
             put(PALETTE_FOLDER, DEFAULT_PALETTE_FOLDER_LOCATION);
         }});
@@ -135,7 +137,6 @@ class EncassLinkerTest {
     @Test
     void linkPortalTemplateDisabledFlag() throws DocumentParseException {
         Bundle fullBundle = new Bundle();
-        ServiceAndPolicyLoaderUtil.setAnnotatePortalIntegrationAssertion("false");
         myEncass.setProperties(new HashMap<String, Object>() {{
             put(PALETTE_FOLDER, DEFAULT_PALETTE_FOLDER_LOCATION);
         }});
@@ -159,7 +160,7 @@ class EncassLinkerTest {
     @Test
     void testMigratePortalAssertionFlag() throws DocumentParseException {
         Bundle fullBundle = new Bundle();
-        ServiceAndPolicyLoaderUtil.setAnnotatePortalIntegrationAssertion("true");
+        System.setProperty(MIGRATE_PORTAL_INTEGRATIONS_ASSERTIONS_PROPERTY, "true");
         myEncass.setProperties(new HashMap<String, Object>() {{
             put(PALETTE_FOLDER, DEFAULT_PALETTE_FOLDER_LOCATION);
         }});
@@ -185,7 +186,7 @@ class EncassLinkerTest {
     @Test
     void testPortalFlagForNonPortalManagedEncass() throws DocumentParseException {
         Bundle fullBundle = new Bundle();
-        ServiceAndPolicyLoaderUtil.setAnnotatePortalIntegrationAssertion("true");
+        System.setProperty(MIGRATE_PORTAL_INTEGRATIONS_ASSERTIONS_PROPERTY, "true");
         myEncass.setProperties(new HashMap<String, Object>() {{
             put(PALETTE_FOLDER, DEFAULT_PALETTE_FOLDER_LOCATION);
         }});

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ServiceLinkerTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ServiceLinkerTest.java
@@ -11,7 +11,6 @@ import com.ca.apim.gateway.cagatewayconfig.bundle.loader.ServiceAndPolicyLoaderU
 import com.ca.apim.gateway.cagatewayconfig.util.entity.AnnotationType;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentParseException;
 import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
-import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils;
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.writer.WriteException;
 import com.ca.apim.gateway.cagatewayexport.util.TestUtils;
 import com.ca.apim.gateway.cagatewayexport.util.policy.PolicyXMLSimplifier;
@@ -29,13 +28,10 @@ import java.util.Set;
 
 import static com.ca.apim.gateway.cagatewayconfig.bundle.loader.ServiceAndPolicyLoaderUtil.MIGRATE_PORTAL_INTEGRATIONS_ASSERTIONS_PROPERTY;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.SERVICE_DETAIL;
-import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.API_PORTAL_ENCASS_INTEGRATION;
-import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.PORTAL_MANAGED_API_FLAG;
+import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.API_PORTAL_INTEGRATION_FLAG;
 import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.*;
-import static com.ca.apim.gateway.cagatewayconfig.util.properties.PropertyConstants.L7_TEMPLATE;
 import static com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentUtils.getSingleElement;
 import static com.ca.apim.gateway.cagatewayexport.util.TestUtils.*;
-import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -64,6 +60,12 @@ class ServiceLinkerTest {
     private static final String SERVICE_POLICY_WITH_PORTAL_INTEGRATION_DISABLED = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
             "<wsp:Policy xmlns:L7p=\"http://www.layer7tech.com/ws/policy\" xmlns:wsp=\"http://schemas.xmlsoap.org/ws/2002/12/policy\">\n" +
             "    <wsp:All wsp:Usage=\"Required\">\n" +
+            "        <L7p:ApiPortalIntegration>\n" +
+            "        <L7p:Enabled booleanValue=\"false\"/>" +
+            "            <L7p:ApiGroup stringValue=\"\"/>\n" +
+            "            <L7p:ApiId stringValue=\"71886958-5b81-4058-85c0-3505aeb14231\"/>\n" +
+            "            <L7p:PortalManagedApiFlag stringValue=\"L7p:ApiPortalManagedServiceAssertion\"/>\n" +
+            "        </L7p:ApiPortalIntegration>" +
             "        <L7p:CommentAssertion>\n" +
             "            <L7p:Comment stringValue=\"Policy Fragment: includedPolicy\"/>\n" +
             "        </L7p:CommentAssertion>\n" +
@@ -162,10 +164,10 @@ class ServiceLinkerTest {
         fullBundle.setFolderTree(folderTree);
         linker.link(myService, fullBundle, bundle);
         Set<Annotation> annotations = myService.getAnnotations();
-        assertNull(annotations);
+        assertTrue(annotations.isEmpty());
 
         Element updatedPolicy =  myService.getPolicyXML();
-        assertThrows(DocumentParseException.class, () -> getSingleElement(updatedPolicy, PORTAL_MANAGED_API_FLAG));
+        assertDoesNotThrow(() -> getSingleElement(updatedPolicy, API_PORTAL_INTEGRATION_FLAG));
     }
 
     @Test
@@ -186,10 +188,10 @@ class ServiceLinkerTest {
         fullBundle.setFolderTree(folderTree);
         linker.link(myService, fullBundle, bundle);
         Set<Annotation> annotations = myService.getAnnotations();
-        assertNull(annotations);
+        assertTrue(annotations.isEmpty());
 
         Element updatedPolicy =  myService.getPolicyXML();
-        assertThrows(DocumentParseException.class, () -> getSingleElement(updatedPolicy, PORTAL_MANAGED_API_FLAG));
+        assertDoesNotThrow(() -> getSingleElement(updatedPolicy, API_PORTAL_INTEGRATION_FLAG));
     }
 
     @Test
@@ -211,11 +213,11 @@ class ServiceLinkerTest {
         fullBundle.setFolderTree(folderTree);
         linker.link(myService, fullBundle, bundle);
         Set<Annotation> annotations = myService.getAnnotations();
-        assertNotNull(annotations);
+        assertFalse(annotations.isEmpty());
         assertTrue(annotations.contains(new Annotation(AnnotationType.BUNDLE)));
 
         Element updatedPolicy =  myService.getPolicyXML();
-        assertThrows(DocumentParseException.class, () -> getSingleElement(updatedPolicy, PORTAL_MANAGED_API_FLAG));
+        assertThrows(DocumentParseException.class, () -> getSingleElement(updatedPolicy, API_PORTAL_INTEGRATION_FLAG));
     }
 
 
@@ -238,10 +240,10 @@ class ServiceLinkerTest {
         fullBundle.setFolderTree(folderTree);
         linker.link(myService, fullBundle, bundle);
         Set<Annotation> annotations = myService.getAnnotations();
-        assertNull(annotations);
+        assertTrue(annotations.isEmpty());
 
         Element updatedPolicy =  myService.getPolicyXML();
-        assertThrows(DocumentParseException.class, () -> getSingleElement(updatedPolicy, PORTAL_MANAGED_API_FLAG));
+        assertDoesNotThrow(() -> getSingleElement(updatedPolicy, API_PORTAL_INTEGRATION_FLAG));
     }
 
 }

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ServiceLinkerTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ServiceLinkerTest.java
@@ -11,6 +11,7 @@ import com.ca.apim.gateway.cagatewayconfig.util.xml.DocumentTools;
 import com.ca.apim.gateway.cagatewayexport.tasks.explode.writer.WriteException;
 import com.ca.apim.gateway.cagatewayexport.util.TestUtils;
 import com.ca.apim.gateway.cagatewayexport.util.policy.PolicyXMLSimplifier;
+import com.ca.apim.gateway.cagatewayexport.util.policy.ServicePolicyXMLSimplifier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -27,11 +28,13 @@ class ServiceLinkerTest {
 
     @Mock
     private PolicyXMLSimplifier policyXMLSimplifier;
+    @Mock
+    private ServicePolicyXMLSimplifier servicePolicyXMLSimplifier;
     private ServiceLinker linker;
 
     @BeforeEach
     void before() {
-        linker = new ServiceLinker(DocumentTools.INSTANCE, policyXMLSimplifier);
+        linker = new ServiceLinker(DocumentTools.INSTANCE, policyXMLSimplifier, servicePolicyXMLSimplifier);
     }
 
     @Test

--- a/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ServiceLinkerTest.java
+++ b/gateway-export-plugin/src/test/java/com/ca/apim/gateway/cagatewayexport/tasks/explode/linker/ServiceLinkerTest.java
@@ -27,6 +27,7 @@ import org.w3c.dom.Element;
 import java.util.HashMap;
 import java.util.Set;
 
+import static com.ca.apim.gateway.cagatewayconfig.bundle.loader.ServiceAndPolicyLoaderUtil.MIGRATE_PORTAL_INTEGRATIONS_ASSERTIONS_PROPERTY;
 import static com.ca.apim.gateway.cagatewayconfig.util.gateway.BundleElementNames.SERVICE_DETAIL;
 import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.API_PORTAL_ENCASS_INTEGRATION;
 import static com.ca.apim.gateway.cagatewayconfig.util.policy.PolicyXMLElements.PORTAL_MANAGED_API_FLAG;
@@ -71,6 +72,8 @@ class ServiceLinkerTest {
 
     @BeforeEach
     void before() {
+        System.setProperty(MIGRATE_PORTAL_INTEGRATIONS_ASSERTIONS_PROPERTY,
+                ServiceAndPolicyLoaderUtil.MIGRATE_PORTAL_INTEGRATIONS_ASSERTIONS_PROPERTY_DEFAULT);
         linker = new ServiceLinker(DocumentTools.INSTANCE, policyXMLSimplifier, new ServicePolicyXMLSimplifier());
     }
 
@@ -147,7 +150,6 @@ class ServiceLinkerTest {
         myService = createService("myService", SERVICE_POLICY_WITH_PORTAL_INTEGRATION);
         bundle = new Bundle();
         bundle.addEntity(myService);
-        ServiceAndPolicyLoaderUtil.setAnnotatePortalIntegrationAssertion("false");
         myService.setProperties(new HashMap<String, Object>() {{
             put(PALETTE_FOLDER, DEFAULT_PALETTE_FOLDER_LOCATION);
         }});
@@ -172,7 +174,6 @@ class ServiceLinkerTest {
         myService = createService("myService", SERVICE_POLICY_WITH_PORTAL_INTEGRATION_DISABLED);
         bundle = new Bundle();
         bundle.addEntity(myService);
-        ServiceAndPolicyLoaderUtil.setAnnotatePortalIntegrationAssertion("false");
         myService.setProperties(new HashMap<String, Object>() {{
             put(PALETTE_FOLDER, DEFAULT_PALETTE_FOLDER_LOCATION);
         }});
@@ -197,7 +198,7 @@ class ServiceLinkerTest {
         myService = createService("myService", SERVICE_POLICY_WITH_PORTAL_INTEGRATION);
         bundle = new Bundle();
         bundle.addEntity(myService);
-        ServiceAndPolicyLoaderUtil.setAnnotatePortalIntegrationAssertion("true");
+        System.setProperty(MIGRATE_PORTAL_INTEGRATIONS_ASSERTIONS_PROPERTY, "true");
         myService.setProperties(new HashMap<String, Object>() {{
             put(PALETTE_FOLDER, DEFAULT_PALETTE_FOLDER_LOCATION);
         }});
@@ -224,7 +225,7 @@ class ServiceLinkerTest {
         myService = createService("myService", SERVICE_POLICY_WITH_PORTAL_INTEGRATION_DISABLED);
         bundle = new Bundle();
         bundle.addEntity(myService);
-        ServiceAndPolicyLoaderUtil.setAnnotatePortalIntegrationAssertion("true");
+        System.setProperty(MIGRATE_PORTAL_INTEGRATIONS_ASSERTIONS_PROPERTY, "true");
         myService.setProperties(new HashMap<String, Object>() {{
             put(PALETTE_FOLDER, DEFAULT_PALETTE_FOLDER_LOCATION);
         }});


### PR DESCRIPTION
## Description  

- Change the default value of **com.ca.apim.export.handleDuplicateNames** system property from false to true.
- Introduce a new system property **com.ca.apim.export.migratePortalIntegrationAssertions** system property with default value false.
- With the above property set to true, policy-plugin should export the portal managed ENCAS/SERVICE entities with @bundle annotation and l7Template=true.
- Introduce a new system property **com.ca.apim.build.ignoreAnnotations** system property with default value false.
- Functional Test Results: https://apim-teamcity.lvn.broadcom.net:8443/buildConfiguration/ApiGateway_DevPluginFunctionalTest_PullRequestBuilder/4880341

## Checklist
- [x] Pull Request Created
- [ ] Unit tests have been added
- [ ] Integration/Functional test cases have been written and automated
