### PR TITLE
Use consistent machine identities for the bundle entities across generations

### DIFF
--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/beans/Encass.java
@@ -183,6 +183,9 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
 
             @Override
             public String getId() {
+                if (StringUtils.isNotBlank(getUniqueEntityName()) && isBundle()) {
+                    return IdGenerator.generate(getUniqueEntityName());
+                }
                 AnnotatedEntity annotatedEntity = getAnnotatedEntity();
                 if (annotatedEntity != null && StringUtils.isNotBlank(annotatedEntity.getId())) {
                     return annotatedEntity.getId();
@@ -192,6 +195,9 @@ public class Encass extends GatewayEntity implements AnnotableEntity {
 
             @Override
             public String getGuid() {
+                if (StringUtils.isNotBlank(getUniqueEntityName()) && isBundle()) {
+                    return IdGenerator.generateGuid(getUniqueEntityName());
+                }
                 AnnotatedEntity annotatedEntity = getAnnotatedEntity();
                 if (annotatedEntity != null && StringUtils.isNotBlank(annotatedEntity.getGuid())) {
                     return annotatedEntity.getGuid();

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncapsulatedAssertionBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncapsulatedAssertionBuilder.java
@@ -142,6 +142,10 @@ public class EncapsulatedAssertionBuilder implements PolicyAssertionBuilder {
                 encass.setId(idGenerator.generate());
             }
             encassName = annotatedBundle.applyUniqueName(encassName, EntityBuilder.BundleType.DEPLOYMENT, encass.isParentEntityShared());
+            // Use consistent machine identities for the bundle/shared entities across generations
+            if (encass.isBundle()) {
+                encassGuid = IdGenerator.generateGuid(encassName);
+            }
         }
         Element encapsulatedAssertionConfigNameElement = createElementWithAttribute(
                 policyBuilderContext.getPolicyDocument(),

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/bundle/builder/EncassEntityBuilder.java
@@ -163,6 +163,11 @@ public class EncassEntityBuilder implements EntityBuilder {
                 //no need to regenerate id and guid
             }
             uniqueEncassName = annotatedBundle.applyUniqueName(name, BundleType.DEPLOYMENT, isShared);
+            // Use consistent machine identities for the bundle/shared entities across generations
+            if (encass.isBundle()) {
+                id = IdGenerator.generate(uniqueEncassName);
+                guid = IdGenerator.generateGuid(uniqueEncassName);
+            }
         }
         encass.setUniqueEntityName(uniqueEncassName);
         Element encassAssertionElement = createElementWithAttributesAndChildren(

--- a/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/IdGenerator.java
+++ b/config-builder/src/main/java/com/ca/apim/gateway/cagatewayconfig/util/IdGenerator.java
@@ -7,6 +7,7 @@
 package com.ca.apim.gateway.cagatewayconfig.util;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.Charset;
 import java.security.SecureRandom;
 import java.util.Random;
 import java.util.UUID;
@@ -69,5 +70,18 @@ public class IdGenerator {
 
     public String generateGuid() {
         return UUID.randomUUID().toString();
+    }
+
+    public static String generateGuid(String forName) {
+        return generateUUID(forName + "::guid").toString();
+    }
+
+    public static String generate(String forName) {
+        final UUID uuid = generateUUID(forName + "::id");
+        return hexDump(ByteBuffer.allocate(16).putLong(uuid.getMostSignificantBits()).putLong(uuid.getLeastSignificantBits()).array());
+    }
+
+    private static UUID generateUUID(String forName) {
+        return UUID.nameUUIDFromBytes(forName.getBytes(Charset.forName("utf-8")));
     }
 }


### PR DESCRIPTION

## Description  
Use consistent machine identities for the bundle entities across generations. This change enables the user not to depend on bundle-hints annotation. FYI, in-place upgrades demand the bundle entity with the same id/guid to that of the previous bundle.

## Checklist
- [x] Pull Request Created
- [ ] Unit tests have been added
- [ ] Integration/Functional test cases have been written and automated
